### PR TITLE
Make the "users" attribute of Schedule objects not be paginated (because...

### DIFF
--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -252,6 +252,7 @@ class Schedules(Collection):
 
 
 class ScheduleUsers(Collection):
+    name = 'users'
     paginated = False
 
 
@@ -405,7 +406,7 @@ class Schedule(Container):
         kwargs[Container.ATTR_NAME_OVERRIDE_KEY] = {"users": "schedule_users"}
         Container.__init__(self, *args, **kwargs)
         self.overrides = Overrides(self.pagerduty, self)
-        self.users = Users(self.pagerduty, self)
+        self.users = ScheduleUsers(self.pagerduty, self)
         self.entries = Entries(self.pagerduty, self)
 
 


### PR DESCRIPTION
This should probably be pulled before #5 (otherwise, `.schedules.list()[0].users.list()` hangs forever)

It's kind of annoying that sometimes `/users` is paginated and sometimes it isn't. Sorry for not catching this in my tests of the original pagination PR.
