### PR TITLE
Use setuptools, it's better

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 execfile('pygerduty/version.py')
 


### PR DESCRIPTION
How do you live without `python setup.py develop`?
