### PR TITLE
Add support for tox, Travis, and (maybe) Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+    - "2.6"
+    - "2.7"
+    - "3.3"
+    - "3.4"
+install:
+    - "pip install ."
+    - "pip install tox"
+script: tox

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -11,7 +11,7 @@ except ImportError:
 
 
 __author__ = "Gary M. Josack <gary@dropbox.com>"
-from version import __version__, version_info
+from version import __version__, version_info  # noqa
 
 
 # TODO:
@@ -295,14 +295,23 @@ class LogEntries(Collection):
 
 class Notes(Collection):
     paginated = False
-    def update(self, *args, **kwargs): raise NotImplementedError()
-    def count(self, *args, **kwargs): raise NotImplementedError()
-    def show(self, *args, **kwargs): raise NotImplementedError()
-    def delete(self, *args, **kwargs): raise NotImplementedError()
+
+    def update(self, *args, **kwargs):
+        raise NotImplementedError()
+
+    def count(self, *args, **kwargs):
+        raise NotImplementedError()
+
+    def show(self, *args, **kwargs):
+        raise NotImplementedError()
+
+    def delete(self, *args, **kwargs):
+        raise NotImplementedError()
 
 
 class Container(object):
     ATTR_NAME_OVERRIDE_KEY = '_attr_name_override'
+
     def __init__(self, collection, **kwargs):
         # This class depends on the existance on the _kwargs attr.
         # Use object's __setattr__ to initialize.
@@ -403,6 +412,7 @@ class Incident(Container):
 class Note(Container):
     pass
 
+
 class Alert(Container):
     pass
 
@@ -421,6 +431,7 @@ class Override(Container):
 
 class NotificationRule(Container):
     pass
+
 
 class ContactMethod(Container):
     pass
@@ -579,7 +590,7 @@ class PagerDuty(object):
     def execute_request(self, request):
         try:
             response = urllib2.urlopen(request, timeout=self.timeout).read()
-        except urllib2.HTTPError, err:
+        except urllib2.HTTPError as err:
             if err.code / 100 == 2:
                 response = err.read()
             elif err.code == 400:

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,12 @@
 
 from setuptools import setup
 
-execfile('pygerduty/version.py')
+with open('pygerduty/version.py') as version_file:
+    exec(compile(version_file.read(), version_file.name, 'exec'))
 
 kwargs = {
     "name": "pygerduty",
-    "version": str(__version__),
+    "version": str(__version__),  # noqa
     "packages": ["pygerduty"],
     "scripts": ["bin/grab_oncall.py"],
     "description": "Python Client Library for PagerDuty's REST API",

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+project = pygerduty
+# These should match the travis env list
+envlist = py26,py27,py33,py34
+
+[testenv]
+install_command = pip install --use-wheel {opts} {packages}
+deps = flake8
+commands =
+    flake8 {[tox]project} setup.py
+
+[flake8]
+ignore = E265,E309,E501


### PR DESCRIPTION
Because `execfile` went away in py3, this package won't even install. 

I added a basic tox.ini that calls flake8, and tested it on py26, py27, py33, and py34. There are still no tests, so I don't know whether other Python 3 issues lurk, but at least we can try now.

https://travis-ci.org/aclevy/pygerduty/builds/56747652