### PR TITLE
Handle 'self' fields

### DIFF
--- a/pygerduty/version.py
+++ b/pygerduty/version.py
@@ -1,2 +1,2 @@
-version_info = (0, 28)
+version_info = (0, 29)
 __version__ = '.'.join(str(v) for v in version_info)


### PR DESCRIPTION
PagerDuty recently added a 'self' field to most of their REST API
responses.  Work around the conflict with Python's own 'self' identifier
by renaming PagerDuty's 'self' field to 'self_url'.

Fixes #23.