### PR TITLE
add max_403_retries argument to PagerDuty constructor

### DIFF
--- a/pygerduty/version.py
+++ b/pygerduty/version.py
@@ -1,2 +1,2 @@
-version_info = (0, 28)
+version_info = (0, 28, 1)
 __version__ = '.'.join(str(v) for v in version_info)


### PR DESCRIPTION
Heavy users of the API will see an occasional 403.
This allows a configurable number of retries with a back-off of 1s
for each retry - e.g. the 2nd retry waits for 2s before trying.
The current implementation is simply a recursive call of execute_request.

Example usage:
  pager = pygerduty.PagerDuty("mycompany", key, max_403_retries=3)