### PR TITLE
Add support for Python 2 and 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: python
-python:
-    - "2.6"
-    - "2.7"
-    - "3.3"
-    - "3.4"
+
+# Keep in-sync with tox.ini.
+env:
+    - TOXENV=py26
+    - TOXENV=py27
+    - TOXENV=py33
+    - TOXENV=py34
+
 install:
     - "pip install ."
     - "pip install tox"
+
 script: tox

--- a/README.rst
+++ b/README.rst
@@ -22,10 +22,7 @@ If you want to install from source, then ``python setup.py install``.
 Requirements
 ============
 
-Pygerduty is tested against >= Python 2.5, Python < 3
-
-``simplejson`` is required on Python2.5
-
+Python 2.6, 2.7, or >= 3.3.
 
 Documentation
 =============

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -13,7 +13,7 @@ except ImportError:
 
 
 __author__ = "Gary M. Josack <gary@dropbox.com>"
-from version import __version__, version_info  # noqa
+from .version import __version__, version_info  # noqa
 
 
 # TODO:

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -1,15 +1,9 @@
-import copy
-import urllib
-import urllib.error
-import urllib.parse
-import urllib.request
 import base64
+import copy
+import json
 import time
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
+from six.moves import urllib
 
 
 __author__ = "Gary M. Josack <gary@dropbox.com>"

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -628,7 +628,7 @@ class PagerDuty(object):
             else:
                 new_qp.append((key, value))
 
-        return urllib.urlencode(new_qp)
+        return urllib.parse.urlencode(new_qp)
 
     def request(self, method, path, query_params=None, data=None,
                 extra_headers=None):

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -204,7 +204,7 @@ class MaintenanceWindows(Collection):
 
 class Incidents(Collection):
     def update(self, requester_id, *args):
-        path = "{}".formatself.name
+        path = "{}".format(self.name)
         data = {"requester_id": requester_id, self.name: args}
         response = self.pagerduty.request("PUT", path, data=json.dumps(data))
         return self.container(self, **response.get(self.sname, {}))
@@ -634,7 +634,7 @@ class PagerDuty(object):
                 extra_headers=None):
         auth = None
         if self.api_token:
-            auth = "Token token={}".formatself.api_token
+            auth = "Token token={}".format(self.api_token)
         elif self.basic_auth:
             b64_string = "{}:{}".format(**self.basic_auth)
             auth = "Basic {}".format(base64.b64encode(b64_string))

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -592,13 +592,13 @@ class PagerDuty(object):
 
     def execute_request(self, request, retry_count=0):
         try:
-            response = urllib.request.urlopen(request,
-                                              timeout=self.timeout).read()
+            response = (urllib.request.urlopen(request, timeout=self.timeout).
+                        read().decode("utf-8"))
         except urllib.error.HTTPError as err:
             if err.code / 100 == 2:
-                response = err.read()
+                response = err.read().decode("utf-8")
             elif err.code == 400:
-                raise BadRequest(json.loads(err.read()))
+                raise BadRequest(json.loads(err.read().decode("utf-8")))
             elif err.code == 403:
                 if retry_count < self.max_403_retries:
                     time.sleep(1 * (retry_count + 1))

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -335,7 +335,7 @@ class Container(object):
                     return Container(Collection(self.pagerduty), **value)
             return value
 
-        for key, value in kwargs.iteritems():
+        for key, value in kwargs.items():
             if self._attr_overrides and key in self._attr_overrides:
                 key = self._attr_overrides[key]
             if isinstance(value, list):
@@ -357,7 +357,7 @@ class Container(object):
         self._kwargs[name] = value
 
     def __str__(self):
-        attrs = ["{}={}".format(k, repr(v)) for k, v in self._kwargs.iteritems()]
+        attrs = ["{}={}".format(k, repr(v)) for k, v in self._kwargs.items()]
         return "<{}: {}>".format(self.__class__.__name__, ", ".join(attrs))
 
     def __repr__(self):
@@ -367,9 +367,9 @@ class Container(object):
         json_dict = {}
         overriden_attrs = dict()
         if self._attr_overrides:
-            for key, value in self._attr_overrides.iteritems():
+            for key, value in self._attr_overrides.items():
                 overriden_attrs[value] = key
-        for key, value in self._kwargs.iteritems():
+        for key, value in self._kwargs.items():
             if key in overriden_attrs:
                 key = overriden_attrs[key]
             if isinstance(value, Container):

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -31,8 +31,8 @@ class IntegrationAPIError(Error):
         self.message = message
 
     def __str__(self):
-        return "Creating {} event failed: {}".format(self.event_type,
-                                                     self.message)
+        return "Creating {0} event failed: {1}".format(self.event_type,
+                                                       self.message)
 
 
 class BadRequest(Error):
@@ -46,7 +46,7 @@ class BadRequest(Error):
         Error.__init__(self, *args, **kwargs)
 
     def __str__(self):
-        return "{} ({}): {}".format(
+        return "{0} ({1}): {2}".format(
             self.message, self.code, self.errors)
 
 
@@ -67,9 +67,9 @@ class Collection(object):
         self.base_container = base_container
 
     def create(self, **kwargs):
-        path = "{}".format(self.name)
+        path = "{0}".format(self.name)
         if self.base_container:
-            path = "{}/{}/{}".format(
+            path = "{0}/{1}/{2}".format(
                 self.base_container.collection.name,
                 self.base_container.id, self.name)
 
@@ -86,9 +86,9 @@ class Collection(object):
         return self.container(self, **response.get(self.sname, {}))
 
     def update(self, entity_id, **kwargs):
-        path = "{}/{}".format(self.name, entity_id)
+        path = "{0}/{1}".format(self.name, entity_id)
         if self.base_container:
-            path = "{}/{}/{}/{}".format(
+            path = "{0}/{1}/{2}/{3}".format(
                 self.base_container.collection.name,
                 self.base_container.id, self.name, entity_id)
 
@@ -113,13 +113,13 @@ class Collection(object):
     def _list_no_pagination(self, **kwargs):
         path = self.name
         if self.base_container:
-            path = "{}/{}/{}".format(
+            path = "{0}/{1}/{2}".format(
                 self.base_container.collection.name,
                 self.base_container.id, self.name)
 
         suffix_path = kwargs.pop("_suffix_path", None)
         if suffix_path is not None:
-            path += "/{}".format(suffix_path)
+            path += "/{0}".format(suffix_path)
 
         response = self.pagerduty.request("GET", path, query_params=kwargs)
         return self._list_response(response)
@@ -156,14 +156,14 @@ class Collection(object):
                     break
 
     def count(self, **kwargs):
-        path = "{}/count".format(self.name)
+        path = "{0}/count".format(self.name)
         response = self.pagerduty.request("GET", path, query_params=kwargs)
         return response.get("total", None)
 
     def show(self, entity_id, **kwargs):
-        path = "{}/{}".format(self.name, entity_id)
+        path = "{0}/{1}".format(self.name, entity_id)
         if self.base_container:
-            path = "{}/{}/{}/{}".format(
+            path = "{0}/{1}/{2}/{3}".format(
                 self.base_container.collection.name,
                 self.base_container.id, self.name, entity_id)
 
@@ -175,9 +175,9 @@ class Collection(object):
             return self.container(self, **response)
 
     def delete(self, entity_id):
-        path = "{}/{}".format(self.name, entity_id)
+        path = "{0}/{1}".format(self.name, entity_id)
         if self.base_container:
-            path = "{}/{}/{}/{}".format(
+            path = "{0}/{1}/{2}/{3}".format(
                 self.base_container.collection.name,
                 self.base_container.id, self.name, entity_id)
 
@@ -190,21 +190,21 @@ class MaintenanceWindows(Collection):
         path = self.name
 
         if "type" in kwargs:
-            path = "{}/{}".format(self.name, kwargs["type"])
+            path = "{0}/{1}".format(self.name, kwargs["type"])
             del kwargs["type"]
 
         response = self.pagerduty.request("GET", path, query_params=kwargs)
         return self._list_response(response)
 
     def update(self, entity_id, **kwargs):
-        path = "{}/{}".format(self.name, entity_id)
+        path = "{0}/{1}".format(self.name, entity_id)
         response = self.pagerduty.request("PUT", path, data=json.dumps(kwargs))
         return self.container(self, **response.get(self.sname, {}))
 
 
 class Incidents(Collection):
     def update(self, requester_id, *args):
-        path = "{}".format(self.name)
+        path = "{0}".format(self.name)
         data = {"requester_id": requester_id, self.name: args}
         response = self.pagerduty.request("PUT", path, data=json.dumps(data))
         return self.container(self, **response.get(self.sname, {}))
@@ -212,18 +212,18 @@ class Incidents(Collection):
 
 class Services(Collection):
     def disable(self, entity_id, requester_id):
-        path = "{}/{}/disable".format(self.name, entity_id)
+        path = "{0}/{1}/disable".format(self.name, entity_id)
         data = {"requester_id": requester_id}
         response = self.pagerduty.request("PUT", path, data=json.dumps(data))
         return response
 
     def enable(self, entity_id):
-        path = "{}/{}/enable".format(self.name, entity_id)
+        path = "{0}/{1}/enable".format(self.name, entity_id)
         response = self.pagerduty.request("PUT", path, data="")
         return response
 
     def regenerate_key(self, entity_id):
-        path = "{}/{}/regenerate_key".format(self.name, entity_id)
+        path = "{0}/{1}/regenerate_key".format(self.name, entity_id)
         response = self.pagerduty.request("POST", path, data="")
         return self.container(self, **response.get(self.sname, {}))
 
@@ -249,7 +249,7 @@ class EscalationRules(Collection):
     paginated = False
 
     def update(self, entity_id, **kwargs):
-        path = "{}/{}/{}/{}".format(
+        path = "{0}/{1}/{2}/{3}".format(
             self.base_container.collection.name,
             self.base_container.id, self.name, entity_id)
         response = self.pagerduty.request("PUT", path, data=json.dumps(kwargs))
@@ -258,7 +258,7 @@ class EscalationRules(Collection):
 
 class Schedules(Collection):
     def update(self, entity_id, **kwargs):
-        path = "{}/{}".format(self.name, entity_id)
+        path = "{0}/{1}".format(self.name, entity_id)
         data = {"overflow": kwargs["overflow"],
                 "schedule": kwargs["schedule"]}
         response = self.pagerduty.request("PUT", path, data=json.dumps(data))
@@ -357,8 +357,8 @@ class Container(object):
         self._kwargs[name] = value
 
     def __str__(self):
-        attrs = ["{}={}".format(k, repr(v)) for k, v in self._kwargs.items()]
-        return "<{}: {}>".format(self.__class__.__name__, ", ".join(attrs))
+        attrs = ["{0}={1}".format(k, repr(v)) for k, v in self._kwargs.items()]
+        return "<{0}: {1}>".format(self.__class__.__name__, ", ".join(attrs))
 
     def __repr__(self):
         return str(self)
@@ -390,7 +390,7 @@ class Incident(Container):
         self.notes = Notes(self.pagerduty, self)
 
     def _do_action(self, verb, requester_id, **kwargs):
-        path = '{}/{}/{}'.format(self.collection.name, self.id, verb)
+        path = '{0}/{1}/{2}'.format(self.collection.name, self.id, verb)
         data = {'requester_id': requester_id}
         data.update(kwargs)
         self.pagerduty.request("PUT", path, data=json.dumps(data))
@@ -513,8 +513,8 @@ class PagerDuty(object):
         self.api_token = api_token
         self.basic_auth = basic_auth
         self.subdomain = subdomain
-        self._host = "{}.pagerduty.com".format(subdomain)
-        self._api_base = "https://{}/api/v1/".format(self._host)
+        self._host = "{0}.pagerduty.com".format(subdomain)
+        self._api_base = "https://{0}/api/v1/".format(self._host)
         self.timeout = timeout
         self.max_403_retries = max_403_retries
 
@@ -606,8 +606,8 @@ class PagerDuty(object):
                 else:
                     raise
             elif err.code == 404:
-                raise NotFound("URL ({}) Not Found."
-                               .format(request.get_full_url()))
+                raise NotFound("URL ({0}) Not Found.".format(
+                    request.get_full_url()))
             else:
                 raise
 
@@ -624,7 +624,7 @@ class PagerDuty(object):
         for key, value in query_params.items():
             if isinstance(value, (list, set, tuple)):
                 for elem in value:
-                    new_qp.append(("{}[]".format(key), elem))
+                    new_qp.append(("{0}[]".format(key), elem))
             else:
                 new_qp.append((key, value))
 
@@ -634,10 +634,10 @@ class PagerDuty(object):
                 extra_headers=None):
         auth = None
         if self.api_token:
-            auth = "Token token={}".format(self.api_token)
+            auth = "Token token={0}".format(self.api_token)
         elif self.basic_auth:
-            b64_string = "{}:{}".format(**self.basic_auth)
-            auth = "Basic {}".format(base64.b64encode(b64_string))
+            b64_string = "{0}:{1}".format(**self.basic_auth)
+            auth = "Basic {0}".format(base64.b64encode(b64_string))
 
         headers = {
             "Content-type": "application/json",
@@ -652,7 +652,7 @@ class PagerDuty(object):
 
         url = urllib.parse.urljoin(self._api_base, path)
         if query_params:
-            url += "?{}".format(query_params)
+            url += "?{0}".format(query_params)
 
         request = urllib.request.Request(url, data=data, headers=headers)
         request.get_method = lambda: method.upper()

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -1,6 +1,7 @@
 import copy
 import urllib
-import urllib2
+import urllib.error
+import urllib.request
 import urlparse
 import base64
 import time
@@ -548,9 +549,9 @@ class PagerDuty(object):
             "client_url": client_url
         }
 
-        request = urllib2.Request(PagerDuty.INTEGRATION_API_URL,
-                                  data=json.dumps(data),
-                                  headers=headers)
+        request = urllib.request.Request(PagerDuty.INTEGRATION_API_URL,
+                                         data=json.dumps(data),
+                                         headers=headers)
         response = self.execute_request(request)
 
         if not response["status"] == "success":
@@ -591,8 +592,9 @@ class PagerDuty(object):
 
     def execute_request(self, request, retry_count=0):
         try:
-            response = urllib2.urlopen(request, timeout=self.timeout).read()
-        except urllib2.HTTPError as err:
+            response = urllib.request.urlopen(request,
+                                              timeout=self.timeout).read()
+        except urllib.error.HTTPError as err:
             if err.code / 100 == 2:
                 response = err.read()
             elif err.code == 400:
@@ -652,7 +654,7 @@ class PagerDuty(object):
         if query_params:
             url += "?{}".format(query_params)
 
-        request = urllib2.Request(url, data=data, headers=headers)
+        request = urllib.request.Request(url, data=data, headers=headers)
         request.get_method = lambda: method.upper()
 
         return self.execute_request(request)

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -30,8 +30,8 @@ class IntegrationAPIError(Error):
         self.message = message
 
     def __str__(self):
-        return "Creating %s event failed: %s" % (self.event_type,
-                                                 self.message)
+        return "Creating {} event failed: {}".format(self.event_type,
+                                                     self.message)
 
 
 class BadRequest(Error):
@@ -45,7 +45,7 @@ class BadRequest(Error):
         Error.__init__(self, *args, **kwargs)
 
     def __str__(self):
-        return "%s (%s): %s" % (
+        return "{} ({}): {}".format(
             self.message, self.code, self.errors)
 
 
@@ -66,9 +66,9 @@ class Collection(object):
         self.base_container = base_container
 
     def create(self, **kwargs):
-        path = "%s" % self.name
+        path = "{}".format(self.name)
         if self.base_container:
-            path = "%s/%s/%s" % (
+            path = "{}/{}/{}".format(
                 self.base_container.collection.name,
                 self.base_container.id, self.name)
 
@@ -85,9 +85,9 @@ class Collection(object):
         return self.container(self, **response.get(self.sname, {}))
 
     def update(self, entity_id, **kwargs):
-        path = "%s/%s" % (self.name, entity_id)
+        path = "{}/{}".format(self.name, entity_id)
         if self.base_container:
-            path = "%s/%s/%s/%s" % (
+            path = "{}/{}/{}/{}".format(
                 self.base_container.collection.name,
                 self.base_container.id, self.name, entity_id)
 
@@ -112,7 +112,7 @@ class Collection(object):
     def _list_no_pagination(self, **kwargs):
         path = self.name
         if self.base_container:
-            path = "%s/%s/%s" % (
+            path = "{}/{}/{}".format(
                 self.base_container.collection.name,
                 self.base_container.id, self.name)
 
@@ -155,14 +155,14 @@ class Collection(object):
                     break
 
     def count(self, **kwargs):
-        path = "%s/count" % self.name
+        path = "{}/count".format(self.name)
         response = self.pagerduty.request("GET", path, query_params=kwargs)
         return response.get("total", None)
 
     def show(self, entity_id, **kwargs):
-        path = "%s/%s" % (self.name, entity_id)
+        path = "{}/{}".format(self.name, entity_id)
         if self.base_container:
-            path = "%s/%s/%s/%s" % (
+            path = "{}/{}/{}/{}".format(
                 self.base_container.collection.name,
                 self.base_container.id, self.name, entity_id)
 
@@ -174,9 +174,9 @@ class Collection(object):
             return self.container(self, **response)
 
     def delete(self, entity_id):
-        path = "%s/%s" % (self.name, entity_id)
+        path = "{}/{}".format(self.name, entity_id)
         if self.base_container:
-            path = "%s/%s/%s/%s" % (
+            path = "{}/{}/{}/{}".format(
                 self.base_container.collection.name,
                 self.base_container.id, self.name, entity_id)
 
@@ -189,21 +189,21 @@ class MaintenanceWindows(Collection):
         path = self.name
 
         if "type" in kwargs:
-            path = "%s/%s" % (self.name, kwargs["type"])
+            path = "{}/{}".format(self.name, kwargs["type"])
             del kwargs["type"]
 
         response = self.pagerduty.request("GET", path, query_params=kwargs)
         return self._list_response(response)
 
     def update(self, entity_id, **kwargs):
-        path = "%s/%s" % (self.name, entity_id)
+        path = "{}/{}".format(self.name, entity_id)
         response = self.pagerduty.request("PUT", path, data=json.dumps(kwargs))
         return self.container(self, **response.get(self.sname, {}))
 
 
 class Incidents(Collection):
     def update(self, requester_id, *args):
-        path = "%s" % self.name
+        path = "{}".formatself.name
         data = {"requester_id": requester_id, self.name: args}
         response = self.pagerduty.request("PUT", path, data=json.dumps(data))
         return self.container(self, **response.get(self.sname, {}))
@@ -211,18 +211,18 @@ class Incidents(Collection):
 
 class Services(Collection):
     def disable(self, entity_id, requester_id):
-        path = "%s/%s/disable" % (self.name, entity_id)
+        path = "{}/{}/disable".format(self.name, entity_id)
         data = {"requester_id": requester_id}
         response = self.pagerduty.request("PUT", path, data=json.dumps(data))
         return response
 
     def enable(self, entity_id):
-        path = "%s/%s/enable" % (self.name, entity_id)
+        path = "{}/{}/enable".format(self.name, entity_id)
         response = self.pagerduty.request("PUT", path, data="")
         return response
 
     def regenerate_key(self, entity_id):
-        path = "%s/%s/regenerate_key" % (self.name, entity_id)
+        path = "{}/{}/regenerate_key".format(self.name, entity_id)
         response = self.pagerduty.request("POST", path, data="")
         return self.container(self, **response.get(self.sname, {}))
 
@@ -248,7 +248,7 @@ class EscalationRules(Collection):
     paginated = False
 
     def update(self, entity_id, **kwargs):
-        path = "%s/%s/%s/%s" % (
+        path = "{}/{}/{}/{}".format(
             self.base_container.collection.name,
             self.base_container.id, self.name, entity_id)
         response = self.pagerduty.request("PUT", path, data=json.dumps(kwargs))
@@ -257,7 +257,7 @@ class EscalationRules(Collection):
 
 class Schedules(Collection):
     def update(self, entity_id, **kwargs):
-        path = "%s/%s" % (self.name, entity_id)
+        path = "{}/{}".format(self.name, entity_id)
         data = {"overflow": kwargs["overflow"],
                 "schedule": kwargs["schedule"]}
         response = self.pagerduty.request("PUT", path, data=json.dumps(data))
@@ -356,8 +356,8 @@ class Container(object):
         self._kwargs[name] = value
 
     def __str__(self):
-        attrs = ["%s=%s" % (k, repr(v)) for k, v in self._kwargs.iteritems()]
-        return "<%s: %s>" % (self.__class__.__name__, ", ".join(attrs))
+        attrs = ["{}={}".format(k, repr(v)) for k, v in self._kwargs.iteritems()]
+        return "<{}: {}>".format(self.__class__.__name__, ", ".join(attrs))
 
     def __repr__(self):
         return str(self)
@@ -389,7 +389,7 @@ class Incident(Container):
         self.notes = Notes(self.pagerduty, self)
 
     def _do_action(self, verb, requester_id, **kwargs):
-        path = '%s/%s/%s' % (self.collection.name, self.id, verb)
+        path = '{}/{}/{}'.format(self.collection.name, self.id, verb)
         data = {'requester_id': requester_id}
         data.update(kwargs)
         self.pagerduty.request("PUT", path, data=json.dumps(data))
@@ -512,8 +512,8 @@ class PagerDuty(object):
         self.api_token = api_token
         self.basic_auth = basic_auth
         self.subdomain = subdomain
-        self._host = "%s.pagerduty.com" % subdomain
-        self._api_base = "https://%s/api/v1/" % self._host
+        self._host = "{}.pagerduty.com".format(subdomain)
+        self._api_base = "https://{}/api/v1/".format(self._host)
         self.timeout = timeout
         self.max_403_retries = max_403_retries
 
@@ -604,7 +604,8 @@ class PagerDuty(object):
                 else:
                     raise
             elif err.code == 404:
-                raise NotFound("URL (%s) Not Found." % request.get_full_url())
+                raise NotFound("URL ({}) Not Found."
+                               .format(request.get_full_url()))
             else:
                 raise
 
@@ -631,10 +632,10 @@ class PagerDuty(object):
                 extra_headers=None):
         auth = None
         if self.api_token:
-            auth = "Token token=%s" % self.api_token
+            auth = "Token token={}".formatself.api_token
         elif self.basic_auth:
-            b64_string = "%s:%s" % self.basic_auth
-            auth = "Basic %s" % base64.b64encode(b64_string)
+            b64_string = "{}:{}".format(**self.basic_auth)
+            auth = "Basic {}".format(base64.b64encode(b64_string))
 
         headers = {
             "Content-type": "application/json",
@@ -649,7 +650,7 @@ class PagerDuty(object):
 
         url = urlparse.urljoin(self._api_base, path)
         if query_params:
-            url += "?%s" % query_params
+            url += "?{}".format(query_params)
 
         request = urllib2.Request(url, data=data, headers=headers)
         request.get_method = lambda: method.upper()

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -1,8 +1,8 @@
 import copy
 import urllib
 import urllib.error
+import urllib.parse
 import urllib.request
-import urlparse
 import base64
 import time
 
@@ -650,7 +650,7 @@ class PagerDuty(object):
         if query_params is not None:
             query_params = self._process_query_params(query_params)
 
-        url = urlparse.urljoin(self._api_base, path)
+        url = urllib.parse.urljoin(self._api_base, path)
         if query_params:
             url += "?{}".format(query_params)
 

--- a/pygerduty/version.py
+++ b/pygerduty/version.py
@@ -1,2 +1,2 @@
-version_info = (0, 28, 1)
+version_info = (0, 28, 2)
 __version__ = '.'.join(str(v) for v in version_info)

--- a/pygerduty/version.py
+++ b/pygerduty/version.py
@@ -1,2 +1,2 @@
-version_info = (0, 28, 2)
+version_info = (0, 29, 0)
 __version__ = '.'.join(str(v) for v in version_info)

--- a/setup.py
+++ b/setup.py
@@ -6,18 +6,15 @@ with open('pygerduty/version.py') as version_file:
     exec(compile(version_file.read(), version_file.name, 'exec'))
 
 kwargs = {
-    "name": "pygerduty",
+    "name": "pygerduty-py3",
     "version": str(__version__),  # noqa
     "packages": ["pygerduty"],
     "scripts": ["bin/grab_oncall.py"],
     "description": "Python Client Library for PagerDuty's REST API",
     "author": "Gary M. Josack",
-    "maintainer": "Gary M. Josack",
     "author_email": "gary@dropbox.com",
-    "maintainer_email": "gary@dropbox.com",
     "license": "MIT",
-    "url": "https://github.com/dropbox/pygerduty",
-    "download_url": "https://github.com/dropbox/pygerduty/archive/master.tar.gz",
+    "url": "https://github.com/cardforcoin/pygerduty",
     "classifiers": [
         "Programming Language :: Python",
         "Topic :: Software Development",

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,50 @@
 #!/usr/bin/env python
 
 from setuptools import setup
+from setuptools.command.test import test as TestCommand
+
+
+class PyTest(TestCommand):
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = ["-v", "-r a"]
+        self.test_suite = True
+
+    def run_tests(self):
+        #import here, cause outside the eggs aren't loaded
+        import pytest
+        pytest.main(self.test_args)
+
 
 with open('pygerduty/version.py') as version_file:
     exec(compile(version_file.read(), version_file.name, 'exec'))
 
 kwargs = {
-    "name": "pygerduty-py3",
+    "name": "pygerduty",
     "version": str(__version__),  # noqa
     "packages": ["pygerduty"],
     "scripts": ["bin/grab_oncall.py"],
     "description": "Python Client Library for PagerDuty's REST API",
     "author": "Gary M. Josack",
+    "maintainer": "Gary M. Josack",
     "author_email": "gary@dropbox.com",
+    "maintainer_email": "gary@dropbox.com",
     "license": "MIT",
-    "url": "https://github.com/cardforcoin/pygerduty",
+    "url": "https://github.com/dropbox/pygerduty",
+    "download_url": "https://github.com/dropbox/pygerduty/archive/master.tar.gz",
     "classifiers": [
         "Programming Language :: Python",
         "Topic :: Software Development",
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Libraries :: Python Modules",
-    ]
+    ],
+    "install_requires": ["six"],
+    "tests_require": [
+        "httpretty",
+        "pytest",
+    ],
+    "cmdclass": {"test": PyTest}
 }
 
 setup(**kwargs)

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+
+import httpretty
+import pygerduty
+import pytest
+
+@httpretty.activate
+def test_unknown_subdomain():
+    httpretty.register_uri(
+        httpretty.GET, "https://contosso.pagerduty.com/api/v1/users/ABCDEFG",
+        body='{"error":{"message":"Account Not Found","code":2007}}', status=404)
+
+    p = pygerduty.PagerDuty("contosso", "password")
+
+    with pytest.raises(pygerduty.NotFound):
+        p.users.show("ABCDEFG")

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -1,0 +1,101 @@
+from __future__ import absolute_import
+
+import httpretty
+import pygerduty
+import textwrap
+
+@httpretty.activate
+def test_get_user():
+    httpretty.register_uri(
+        httpretty.GET, "https://contosso.pagerduty.com/api/v1/users/PIJ90N7",
+        body=textwrap.dedent("""\
+            {
+              "user": {
+                "avatar_url": "https://secure.gravatar.com/avatar/6e1b6fc29a03fc3c13756bd594e314f7.png?d=mm&r=PG",
+                "color": "dark-slate-grey",
+                "email": "bart@example.com",
+                "id": "PIJ90N7",
+                "invitation_sent": true,
+                "job_title": "Developer",
+                "marketing_opt_out": true,
+                "name": "Bart Simpson",
+                "role": "admin",
+                "time_zone": "Eastern Time (US & Canada)",
+                "user_url": "/users/PIJ90N7"
+              }
+            }
+            """), status=200)
+
+    p = pygerduty.PagerDuty("contosso", "password")
+    user = p.users.show("PIJ90N7")
+
+    assert user.id == "PIJ90N7"
+    assert user.name == "Bart Simpson"
+    assert user.role == "admin"
+
+@httpretty.activate
+def test_get_user_contact_methods():
+    httpretty.register_uri(
+        httpretty.GET, "https://contosso.pagerduty.com/api/v1/users/PIJ90N7",
+        body=textwrap.dedent("""\
+            {
+              "user": {
+                "avatar_url": "https://secure.gravatar.com/avatar/6e1b6fc29a03fc3c13756bd594e314f7.png?d=mm&r=PG",
+                "color": "dark-slate-grey",
+                "email": "bart@example.com",
+                "id": "PIJ90N7",
+                "invitation_sent": true,
+                "job_title": "Developer",
+                "marketing_opt_out": true,
+                "name": "Bart Simpson",
+                "role": "admin",
+                "time_zone": "Eastern Time (US & Canada)",
+                "user_url": "/users/PIJ90N7"
+              }
+            }
+            """), status=200),
+    httpretty.register_uri(
+        httpretty.GET, "https://contosso.pagerduty.com/api/v1/users/PIJ90N7/contact_methods",
+        body=textwrap.dedent("""\
+            {
+              "contact_methods": [
+                {
+                  "address": "bart@example.com",
+                  "email": "bart@example.com",
+                  "id": "PZMO0JF",
+                  "label": "Default",
+                  "send_short_email": false,
+                  "type": "email",
+                  "user_id": "PIJ90N7"
+                },
+                {
+                  "address": "9373249222",
+                  "country_code": 1,
+                  "id": "PDGR818",
+                  "label": "Mobile",
+                  "phone_number": "9373249222",
+                  "type": "phone",
+                  "user_id": "PIJ90N7"
+                },
+                {
+                  "address": "9373249222",
+                  "country_code": 1,
+                  "enabled": true,
+                  "id": "P25E95E",
+                  "label": "Mobile",
+                  "phone_number": "9373249222",
+                  "type": "SMS",
+                  "user_id": "PIJ90N7"
+                }
+              ]
+            }
+            """), status=200)
+
+    p = pygerduty.PagerDuty("contosso", "password")
+    user = p.users.show("PIJ90N7")
+    contact_methods = [c for c in user.contact_methods.list()]
+
+    assert len(contact_methods) == 3
+    assert len([c for c in contact_methods if c.type == "email"]) == 1
+    assert len([c for c in contact_methods if c.type == "phone"]) == 1
+    assert len([c for c in contact_methods if c.type == "SMS"]) == 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 project = pygerduty
-# These should match the travis env list
+
+# Keep in-sync with .travis.yml.
 envlist = py26,py27,py33,py34
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ install_command = pip install --use-wheel {opts} {packages}
 deps = flake8
 commands =
     flake8 {[tox]project} setup.py
+    {envpython} setup.py test
 
 [flake8]
 ignore = E265,E309,E501


### PR DESCRIPTION
Fixes #22.

Please note that this pull request will drop support for Python 2.5.

Tested with:
  - CPython 2.6.9
  - CPython 2.7.10
  - CPython 3.3.6
  - CPython 3.4.3

I was forced to add a handful of unit tests to ensure basic functionality across the different runtimes. These tests offer minimal coverage. Tests for paginated responses and writes are missing. The tests that do exist may differ from your house style.