### PR TITLE
Removing EscalationRules loader from EscalationPolicy since it breaks the loading of the rules

### DIFF
--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -434,10 +434,7 @@ class ContactMethod(Container):
 
 
 class EscalationPolicy(Container):
-    def __init__(self, *args, **kwargs):
-        Container.__init__(self, *args, **kwargs)
-        self.escalation_rules = EscalationRules(self.pagerduty, self)
-
+    pass
 
 class EscalationRule(Container):
     pass


### PR DESCRIPTION
Before the escalation_rules would contain a EscalationRules Collection that was actually the EscalationPolicy.

By removing it we now get a list of escalation rules. Which at least is usefull to me at the moment.
I would suspect you want this to return a generator since escalation_policies/:escalation_policy_id/escalation_rules exists in PD's api. however I am unsure how to fix this at the moment. So heres a starting point. Let me know what you would like to see.
