### PR TITLE
Added functionality for Incident

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ MANIFEST
 # Packages
 *.egg
 *.egg-info
+.idea
 dist
 build
 eggs

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -410,9 +410,9 @@ class Incident(Container):
     def acknowledge(self, requester_id):
         self._do_action('acknowledge', requester_id=requester_id)
 
-    def details_log_entry(self):
+    def get_trigger_log_entry(self, **kwargs):
         match = DETAILS_LOG_ENTRY_RE.search(self.trigger_details_html_url)
-        return self.log_entries.show(match.group('log_entry_id'), include=['channel'])
+        return self.log_entries.show(match.group('log_entry_id'), **kwargs)
 
     def reassign(self, user_ids, requester_id):
         """Reassign this incident to a user or list of users

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -2,6 +2,7 @@ import base64
 import copy
 import json
 import time
+import re
 
 import six
 from six.moves import urllib
@@ -10,6 +11,9 @@ from six.moves import urllib
 __author__ = "Gary M. Josack <gary@dropbox.com>"
 from .version import __version__, version_info  # noqa
 
+DETAILS_LOG_ENTRY_RE = re.compile(
+    r'(?P<log_detail>log_entries/[A-Z0-9]+)'
+)
 
 # TODO:
 # Support for Log Entries
@@ -391,17 +395,30 @@ class Incident(Container):
         self.log_entries = LogEntries(self.pagerduty, self)
         self.notes = Notes(self.pagerduty, self)
 
-    def _do_action(self, verb, requester_id, **kwargs):
+    def _do_action(self, verb, requester_id, method='PUT', **kwargs):
         path = '{0}/{1}/{2}'.format(self.collection.name, self.id, verb)
         data = {'requester_id': requester_id}
         data.update(kwargs)
-        self.pagerduty.request("PUT", path, data=json.dumps(data))
+        return self.pagerduty.request(method, path, data=json.dumps(data))
+
+    def has_subject(self):
+        has_subject = False
+        try:
+            self.trigger_summary_data.subject # try to access the subject
+            has_subject = True
+        except: pass
+        return has_subject
 
     def resolve(self, requester_id):
         self._do_action('resolve', requester_id=requester_id)
 
     def acknowledge(self, requester_id):
         self._do_action('acknowledge', requester_id=requester_id)
+
+    def get_details_log_entry(self, requester_id):
+        match = DETAILS_LOG_ENTRY_RE.search(self.trigger_details_html_url)
+        return self._do_action(match.group('log_detail'), requester_id=requester_id,
+                               method='GET', **{'include': ['channel']})
 
     def reassign(self, user_ids, requester_id):
         """Reassign this incident to a user or list of users
@@ -660,6 +677,7 @@ class PagerDuty(object):
             query_params = self._process_query_params(query_params)
 
         url = urllib.parse.urljoin(self._api_base, path)
+
         if query_params:
             url += "?{0}".format(query_params)
 

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -399,7 +399,7 @@ class Incident(Container):
         path = '{0}/{1}/{2}'.format(self.collection.name, self.id, verb)
         data = {'requester_id': requester_id}
         data.update(kwargs)
-        return self.pagerduty.request('GET', path, data=json.dumps(data))
+        return self.pagerduty.request('PUT', path, data=json.dumps(data))
 
     def has_subject(self):
         return hasattr(self.trigger_summary_data, 'subject')

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -402,13 +402,7 @@ class Incident(Container):
         return self.pagerduty.request(method, path, data=json.dumps(data))
 
     def has_subject(self):
-        has_subject = False
-        try:
-            self.trigger_summary_data.subject  # try to access the subject
-            has_subject = True
-        except:
-            pass
-        return has_subject
+        return hasattr(self.trigger_summary_data, 'subject')
 
     def resolve(self, requester_id):
         self._do_action('resolve', requester_id=requester_id)

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -404,9 +404,10 @@ class Incident(Container):
     def has_subject(self):
         has_subject = False
         try:
-            self.trigger_summary_data.subject # try to access the subject
+            self.trigger_summary_data.subject  # try to access the subject
             has_subject = True
-        except: pass
+        except:
+            pass
         return has_subject
 
     def resolve(self, requester_id):


### PR DESCRIPTION
Two pieces of valuable information are not included with an incdient:

1. Whether the summary_details includes a subject or a description
2. The extra data contained in the details log entry

With this small code update, an incident is now aware of both of these items.  There are two new methods for incidents:

1. incident.get_detail_log_entry(requester_id)  #Returns json of log entry
2. incident.has_subject()  # Boolean return, if no subject, than it has details (incident.trigger_summary_data.subject/details)