### PR TITLE
Bump version and fix py3 compat

### DIFF
--- a/pygerduty/events.py
+++ b/pygerduty/events.py
@@ -2,7 +2,7 @@
 # Pagerduty Events API.
 
 from six.moves import urllib
-from common import (
+from .common import (
     _json_dumper,
     Error,
 )

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -2,7 +2,7 @@ import copy
 import re
 import six
 from six.moves import urllib
-from common import (
+from .common import (
     Requester,
     _lower,
     _upper,
@@ -78,7 +78,7 @@ class Collection(object):
     @staticmethod
     def process_kwargs(kwargs):
         new_kwargs = {}
-        for kwarg_key, kwarg_value in kwargs.iteritems():
+        for kwarg_key, kwarg_value in kwargs.items():
             if kwarg_key.endswith('_id'):
                 new_key = Collection.cut_suffix(kwarg_key)
                 new_kwargs[new_key] = Collection.id_to_obj(new_key, kwarg_value)

--- a/pygerduty/version.py
+++ b/pygerduty/version.py
@@ -1,2 +1,2 @@
-version_info = (0, 35, 2)
+version_info = (0, 36, 0)
 __version__ = '.'.join(str(v) for v in version_info)

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
+import sys
 
 
 class PyTest(TestCommand):
@@ -14,7 +15,7 @@ class PyTest(TestCommand):
     def run_tests(self):
         #import here, cause outside the eggs aren't loaded
         import pytest
-        pytest.main(self.test_args)
+        sys.exit(pytest.main(self.test_args))
 
 
 with open('pygerduty/version.py') as version_file:

--- a/tests/container_test.py
+++ b/tests/container_test.py
@@ -45,6 +45,4 @@ def test_to_json_list_convertion_v2():
 
     container = pygerduty.v2.Container(collection, handlers=['test1', 'test2'])
 
-    print container.to_json()
-
     assert {'handlers': ['test1', 'test2']} == container.to_json()


### PR DESCRIPTION
* Fixed issue where `./setup.py test` was returning `0` on test failures
* Fixed py3 compatibility issues. Tests pass on py3 again.
* Bump version in preparation for release.