### PR TITLE
Update _do_action to remove deprecated endpoint

### DIFF
--- a/pygerduty/events.py
+++ b/pygerduty/events.py
@@ -23,7 +23,7 @@ class IntegrationAPIError(Error):
 
 
 class Events(object):
-    def __init__(self, service_key, requester):
+    def __init__(self, service_key, requester=None):
         self.service_key = service_key
         if requester is None:
             self.requester = Requester()

--- a/pygerduty/events.py
+++ b/pygerduty/events.py
@@ -22,9 +22,9 @@ class IntegrationAPIError(Error):
 
 
 class Events(object):
-    def __init__(self, service_key, requester):
+    def __init__(self, service_key):
         self.service_key = service_key
-        self.requester = requester
+        self.requester = pygerduty.common.Requester()
 
     def create_event(self, description, event_type,
                      details, incident_key, **kwargs):

--- a/pygerduty/events.py
+++ b/pygerduty/events.py
@@ -5,6 +5,7 @@ from six.moves import urllib
 from .common import (
     _json_dumper,
     Error,
+    Requester,
 )
 
 INTEGRATION_API_URL =\
@@ -22,9 +23,12 @@ class IntegrationAPIError(Error):
 
 
 class Events(object):
-    def __init__(self, service_key):
+    def __init__(self, service_key, requester):
         self.service_key = service_key
-        self.requester = pygerduty.common.Requester()
+        if requester is None:
+            self.requester = Requester()
+        else:
+            self.requester = requester
 
     def create_event(self, description, event_type,
                      details, incident_key, **kwargs):

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -276,10 +276,6 @@ class Overrides(Collection):
     paginated = False
 
 
-class Entries(Collection):
-    paginated = False
-
-
 class EscalationPolicies(Collection):
     pass
 

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -525,7 +525,6 @@ class Schedule(Container):
         Container.__init__(self, *args, **kwargs)
         self.overrides = Overrides(self.pagerduty, self)
         self.users = ScheduleUsers(self.pagerduty, self)
-        self.entries = Entries(self.pagerduty, self)
 
 
 class ScheduleUser(Container):
@@ -555,6 +554,14 @@ class Entry(Container):
 
 
 class LogEntry(Container):
+    pass
+
+
+class FinalSchedule(Container):
+    pass
+
+
+class RenderSchedule(Container):
     pass
 
 

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -430,9 +430,17 @@ class Incident(Container):
         self.notes = Notes(self.pagerduty, self)
 
     def _do_action(self, verb, requester_id, **kwargs):
-        path = '{0}/{1}/{2}'.format(self.collection.name, self.id, verb)
+        path = '{0}/{1}'.format(self.collection.name, self.id)
+        data = {
+            "incident": {
+                "type": "incident_reference",
+                "status": verb
+            }
+        }
         extra_headers = {'From': requester_id}
-        return self.pagerduty.request('PUT', path, extra_headers=extra_headers)
+
+        return self.pagerduty.request('PUT', path, data=_json_dumper(data),
+                                          extra_headers=extra_headers)
 
     def has_subject(self):
         return hasattr(self.trigger_summary_data, 'subject')

--- a/tests/incident_test.py
+++ b/tests/incident_test.py
@@ -48,3 +48,24 @@ def test_list_incidents_v2():
     assert incidents[0].created_at == '2015-10-06T21:30:42Z'
     assert incidents[0].self_ == 'https://api.pagerduty.com/incidents/PT4KHLK'
     assert len(incidents[0].pending_actions) == 2
+
+
+@httpretty.activate
+def test_verb_action_v2():
+    body1 = open('tests/fixtures/incident_get_v2.json').read()
+    body2 = open('tests/fixtures/incident_put_v2.json').read()
+    httpretty.register_uri(
+        httpretty.GET, "https://api.pagerduty.com/incidents/PT4KHLK", responses=[
+            httpretty.Response(body=body1, status=200),
+            httpretty.Response(body=body2, status=200),
+        ],
+    )
+    httpretty.register_uri(
+        httpretty.PUT, "https://api.pagerduty.com/incidents/PT4KHLK",
+        body=body2, status=200)
+    p = pygerduty.v2.PagerDuty("password")
+    incident = p.incidents.show('PT4KHLK')
+    incident.acknowledge(requester_id='PXPGF42')
+    incident = p.incidents.show('PT4KHLK')
+
+    assert incident.acknowledgements[0].acknowledger.id == 'PXPGF42'


### PR DESCRIPTION
- `incidents/{id}/{verb}` has been deprecated with v2 of the PagerDuty API. Now it requires a PUT request to `incidents/{id}` with data detailing the verb (acknowledge,resolve, escalate, etc).
- Added a test to check that this works.