### PR TITLE
Version 2: Fixing do_action due to deprecated endpoints on incident.

### DIFF
--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -432,14 +432,14 @@ class Incident(Container):
     def _do_action(self, verb, requester_id, **kwargs):
         path = '{0}/{1}'.format(self.collection.name, self.id)
         data = {
-			"incident": {
-				"type": "incident_reference",
-				"status": verb
-			}
-		}
+            "incident": {
+                "type": "incident_reference",
+                "status": verb
+            }
+        }
         extra_headers = {'From': requester_id}
         return self.pagerduty.request('PUT', path, data=_json_dumper(data),
-									extra_headers=extra_headers)
+                                        extra_headers=extra_headers)
 
     def has_subject(self):
         return hasattr(self.trigger_summary_data, 'subject')

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -430,9 +430,16 @@ class Incident(Container):
         self.notes = Notes(self.pagerduty, self)
 
     def _do_action(self, verb, requester_id, **kwargs):
-        path = '{0}/{1}/{2}'.format(self.collection.name, self.id, verb)
+        path = '{0}/{1}'.format(self.collection.name, self.id)
+        data = {
+			"incident": {
+				"type": "incident_reference",
+				"status": verb
+			}
+		}
         extra_headers = {'From': requester_id}
-        return self.pagerduty.request('PUT', path, extra_headers=extra_headers)
+        return self.pagerduty.request('PUT', path, data=_json_dumper(data),
+									extra_headers=extra_headers)
 
     def has_subject(self):
         return hasattr(self.trigger_summary_data, 'subject')

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -439,7 +439,7 @@ class Incident(Container):
         }
         extra_headers = {'From': requester_id}
         return self.pagerduty.request('PUT', path, data=_json_dumper(data),
-                                        extra_headers=extra_headers)
+            extra_headers=extra_headers)
 
     def has_subject(self):
         return hasattr(self.trigger_summary_data, 'subject')

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -438,8 +438,7 @@ class Incident(Container):
             }
         }
         extra_headers = {'From': requester_id}
-        return self.pagerduty.request('PUT', path, data=_json_dumper(data),
-            extra_headers=extra_headers)
+        return self.pagerduty.request('PUT', path, data=_json_dumper(data), extra_headers=extra_headers)
 
     def has_subject(self):
         return hasattr(self.trigger_summary_data, 'subject')

--- a/tests/fixtures/incident_get_v2.json
+++ b/tests/fixtures/incident_get_v2.json
@@ -1,0 +1,50 @@
+{
+  "incident": {
+    "id": "PT4KHLK",
+    "type": "incident",
+    "summary": "[#1234] The server is on fire.",
+    "self": "https://api.pagerduty.com/incidents/PT4KHLK",
+    "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK",
+    "incident_number": 1234,
+    "created_at": "2015-10-06T21:30:42Z",
+    "status": "resolved",
+    "title": "The server is on fire.",
+    "resolve_reason": null,
+    "alert_counts": {
+      "all": 2,
+      "triggered": 0,
+      "resolved": 2
+    },
+    "pending_actions": [
+      {
+        "type": "unacknowledge",
+        "at": "2015-11-10T01:02:52Z"
+      },
+      {
+        "type": "resolve",
+        "at": "2015-11-10T04:31:52Z"
+      }
+    ],
+    "incident_key": "baf7cf21b1da41b4b0221008339ff357",
+    "service": {
+      "id": "PIJ90N7",
+      "type": "generic_email_reference",
+      "summary": "My Mail Service",
+      "self": "https://api.pagerduty.com/services/PIJ90N7",
+      "html_url": "https://subdomain.pagerduty.com/services/PIJ90N7"
+    },
+    "priority": {
+      "id": "P53ZZH5",
+      "type": "priority_reference",
+      "summary": "P2",
+      "self": "https://api.pagerduty.com/priorities/P53ZZH5",
+      "html_url": null
+    },
+    "assignments": [
+      {
+        "at": "2015-11-10T00:31:52Z",
+        "assignee": {
+          "id": "PXPGF42",
+          "type": "user_reference",
+          "summary": "Earline Greenholt",
+          "self": "https://api.pagerduty.com/users/PXPGF42",

--- a/tests/fixtures/incident_get_v2.json
+++ b/tests/fixtures/incident_get_v2.json
@@ -48,3 +48,42 @@
           "type": "user_reference",
           "summary": "Earline Greenholt",
           "self": "https://api.pagerduty.com/users/PXPGF42",
+          "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
+        }
+      }
+    ],
+    "acknowledgements":[],
+    "last_status_change_at": "2015-10-06T21:38:23Z",
+    "last_status_change_by": {
+      "id": "PXPGF42",
+      "type": "user_reference",
+      "summary": "Earline Greenholt",
+      "self": "https://api.pagerduty.com/users/PXPGF42",
+      "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
+    },
+    "first_trigger_log_entry": {
+      "id": "Q02JTSNZWHSEKV",
+      "type": "trigger_log_entry_reference",
+      "summary": "Triggered through the API",
+      "self": "https://api.pagerduty.com/log_entries/Q02JTSNZWHSEKV?incident_id=PT4KHLK",
+      "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK/log_entries/Q02JTSNZWHSEKV"
+    },
+    "escalation_policy": {
+      "id": "PT20YPA",
+      "type": "escalation_policy_reference",
+      "summary": "Another Escalation Policy",
+      "self": "https://api.pagerduty.com/escalation_policies/PT20YPA",
+      "html_url": "https://subdomain.pagerduty.com/escalation_policies/PT20YPA"
+    },
+    "teams": [
+      {
+        "id": "PQ9K7I8",
+        "type": "team_reference",
+        "summary": "Engineering",
+        "self": "https://api.pagerduty.com/teams/PQ9K7I8",
+        "html_url": "https://subdomain.pagerduty.com/teams/PQ9K7I8"
+      }
+    ],
+    "urgency": "high"
+  }
+}

--- a/tests/fixtures/incident_put_v2.json
+++ b/tests/fixtures/incident_put_v2.json
@@ -1,0 +1,50 @@
+          "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
+        }
+      }
+    ],
+    "acknowledgements": [
+      {
+        "at": "2015-11-10T00:32:52Z",
+        "acknowledger": {
+          "id": "PXPGF42",
+          "type": "user_reference",
+          "summary": "Earline Greenholt",
+          "self": "https://api.pagerduty.com/users/PXPGF42",
+          "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
+        }
+      }
+    ],
+    "last_status_change_at": "2015-10-06T21:38:23Z",
+    "last_status_change_by": {
+      "id": "PXPGF42",
+      "type": "user_reference",
+      "summary": "Earline Greenholt",
+      "self": "https://api.pagerduty.com/users/PXPGF42",
+      "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
+    },
+    "first_trigger_log_entry": {
+      "id": "Q02JTSNZWHSEKV",
+      "type": "trigger_log_entry_reference",
+      "summary": "Triggered through the API",
+      "self": "https://api.pagerduty.com/log_entries/Q02JTSNZWHSEKV?incident_id=PT4KHLK",
+      "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK/log_entries/Q02JTSNZWHSEKV"
+    },
+    "escalation_policy": {
+      "id": "PT20YPA",
+      "type": "escalation_policy_reference",
+      "summary": "Another Escalation Policy",
+      "self": "https://api.pagerduty.com/escalation_policies/PT20YPA",
+      "html_url": "https://subdomain.pagerduty.com/escalation_policies/PT20YPA"
+    },
+    "teams": [
+      {
+        "id": "PQ9K7I8",
+        "type": "team_reference",
+        "summary": "Engineering",
+        "self": "https://api.pagerduty.com/teams/PQ9K7I8",
+        "html_url": "https://subdomain.pagerduty.com/teams/PQ9K7I8"
+      }
+    ],
+    "urgency": "high"
+  }
+}

--- a/tests/fixtures/incident_put_v2.json
+++ b/tests/fixtures/incident_put_v2.json
@@ -64,18 +64,6 @@
         }
       }
     ],
-    "acknowledgements": [
-      {
-        "at": "2015-11-10T00:32:52Z",
-        "acknowledger": {
-          "id": "PXPGF42",
-          "type": "user_reference",
-          "summary": "Earline Greenholt",
-          "self": "https://api.pagerduty.com/users/PXPGF42",
-          "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
-        }
-      }
-    ],
     "last_status_change_at": "2015-10-06T21:38:23Z",
     "last_status_change_by": {
       "id": "PXPGF42",

--- a/tests/fixtures/incident_put_v2.json
+++ b/tests/fixtures/incident_put_v2.json
@@ -1,3 +1,65 @@
+{
+  "incident": {
+    "id": "PT4KHLK",
+    "type": "incident",
+    "summary": "[#1234] The server is on fire.",
+    "self": "https://api.pagerduty.com/incidents/PT4KHLK",
+    "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK",
+    "incident_number": 1234,
+    "created_at": "2015-10-06T21:30:42Z",
+    "status": "resolved",
+    "title": "The server is on fire.",
+    "resolve_reason": null,
+    "alert_counts": {
+      "all": 2,
+      "triggered": 0,
+      "resolved": 2
+    },
+    "pending_actions": [
+      {
+        "type": "unacknowledge",
+        "at": "2015-11-10T01:02:52Z"
+      },
+      {
+        "type": "resolve",
+        "at": "2015-11-10T04:31:52Z"
+      }
+    ],
+    "incident_key": "baf7cf21b1da41b4b0221008339ff357",
+    "service": {
+      "id": "PIJ90N7",
+      "type": "generic_email_reference",
+      "summary": "My Mail Service",
+      "self": "https://api.pagerduty.com/services/PIJ90N7",
+      "html_url": "https://subdomain.pagerduty.com/services/PIJ90N7"
+    },
+    "priority": {
+      "id": "P53ZZH5",
+      "type": "priority_reference",
+      "summary": "P2",
+      "self": "https://api.pagerduty.com/priorities/P53ZZH5",
+      "html_url": null
+    },
+    "assignments": [
+      {
+        "at": "2015-11-10T00:31:52Z",
+        "assignee": {
+          "id": "PXPGF42",
+          "type": "user_reference",
+          "summary": "Earline Greenholt",
+          "self": "https://api.pagerduty.com/users/PXPGF42",
+          "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
+        }
+      }
+    ],
+    "acknowledgements": [
+      {
+        "at": "2015-11-10T00:32:52Z",
+        "acknowledger": {
+          "id": "PXPGF42",
+          "type": "user_reference",
+          "summary": "Earline Greenholt",
+          "self": "https://api.pagerduty.com/users/PXPGF42",
           "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
         }
       }

--- a/tests/incident_test.py
+++ b/tests/incident_test.py
@@ -64,8 +64,9 @@ def test_verb_action_v2():
         httpretty.PUT, "https://api.pagerduty.com/incidents/PT4KHLK",
         body=body2, status=200)
     p = pygerduty.v2.PagerDuty("password")
-    incident = p.incidents.show('PT4KHLK')
-    incident.acknowledge(requester_id='PXPGF42')
-    incident = p.incidents.show('PT4KHLK')
+    incident1 = p.incidents.show('PT4KHLK')
+    incident1.acknowledge(requester_id='PXPGF42')
+    incident2 = p.incidents.show('PT4KHLK')
 
-    assert incident.acknowledgements[0].acknowledger.id == 'PXPGF42'
+    assert incident1.acknowledgements == []
+    assert incident2.acknowledgements[0].acknowledger.id == 'PXPGF42'

--- a/tests/incident_test.py
+++ b/tests/incident_test.py
@@ -48,3 +48,24 @@ def test_list_incidents_v2():
     assert incidents[0].created_at == '2015-10-06T21:30:42Z'
     assert incidents[0].self_ == 'https://api.pagerduty.com/incidents/PT4KHLK'
     assert len(incidents[0].pending_actions) == 2
+
+
+@httpretty.activate
+def test_verb_action_v2():
+    body1 = open('tests/fixtures/incident_get_v2.json').read()
+    body2 = open('tests/fixtures/incident_put_v2.json').read()
+    httpretty.register_uri(
+        httpretty.GET, "https://api.pagerduty.com/incidents/PT4KHLK", responses=[
+            httpretty.Response(body=body1, status=200),
+            httpretty.Response(body=body2, status=200),
+        ],
+    )
+    httpretty.register_uri(
+        httpretty.PUT, "https://api.pagerduty.com/incidents/PT4KHLK",
+        body=body2, status=200)
+    p = pygerduty.v2.PagerDuty("password")
+    incident = p.incidents.show('PT4KHLK')
+    incident.acknowledge(requester_id='PXPGF42')
+    incident = p.incidents.show('PT4KHLK')
+
+    assert incident.acknowledgements[0].acknowledger.id == 'PXPGF42'


### PR DESCRIPTION
- `incidents/{id}/{verb}` has been deprecated with v2 of the PagerDuty API. Now it requires a `PUT` request to `incidents/{id}` with data detailing the verb (acknowledge,resolve, escalate, etc).
- Added a test to check that this works.