### PR TITLE
Add requester id to data payload.

### DIFF
--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -429,34 +429,37 @@ class Incident(Container):
         self.log_entries = LogEntries(self.pagerduty, self)
         self.notes = Notes(self.pagerduty, self)
 
-    def _do_action(self, verb, requester_id, **kwargs):
+    def _do_action(self, verb, requester, **kwargs):
         path = '{0}/{1}'.format(self.collection.name, self.id)
         data = {
             "incident": {
                 "type": "incident_reference",
                 "status": verb
-            },
-            "requester_id": requester_id
+            }
         }
-        extra_headers = {'From': requester_id}
+        extra_headers = {'From': requester}
         return self.pagerduty.request('PUT', path, data=_json_dumper(data), extra_headers=extra_headers)
 
     def has_subject(self):
         return hasattr(self.trigger_summary_data, 'subject')
 
-    def resolve(self, requester_id):
-        self._do_action('resolve', requester_id=requester_id)
+    def resolve(self, requester):
+        # Takes email address of the requester.
+        self._do_action('resolved', requester=requester)
 
-    def acknowledge(self, requester_id):
-        self._do_action('acknowledge', requester_id=requester_id)
+    def acknowledge(self, requester):
+        # Takes email address of the requester.
+        self._do_action('acknowledged', requester_id=requester)
 
     def snooze(self, requester_id, duration):
+    # TODO: FIX THIS, GOES TO incidents/id/snooze, cant use _do_action as is.
         self._do_action('snooze', requester_id=requester_id, duration=duration)
 
     def get_trigger_log_entry(self, **kwargs):
         match = TRIGGER_LOG_ENTRY_RE.search(self.trigger_details_html_url)
         return self.log_entries.show(match.group('log_entry_id'), **kwargs)
 
+    # TODO: FIX THIS -- NO LONGER CAN USE _do_action
     def reassign(self, user_ids, requester_id):
         """Reassign this incident to a user or list of users
 

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -435,7 +435,8 @@ class Incident(Container):
             "incident": {
                 "type": "incident_reference",
                 "status": verb
-            }
+            },
+            "requester_id": requester_id
         }
         extra_headers = {'From': requester_id}
         return self.pagerduty.request('PUT', path, data=_json_dumper(data), extra_headers=extra_headers)

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -449,11 +449,11 @@ class Incident(Container):
 
     def acknowledge(self, requester):
         # Takes email address of the requester.
-        self._do_action('acknowledged', requester_id=requester)
+        self._do_action('acknowledged', requester=requester)
 
     def snooze(self, requester_id, duration):
     # TODO: FIX THIS, GOES TO incidents/id/snooze, cant use _do_action as is.
-        self._do_action('snooze', requester_id=requester_id, duration=duration)
+        self._do_action('snooze', requester=requester_id, duration=duration)
 
     def get_trigger_log_entry(self, **kwargs):
         match = TRIGGER_LOG_ENTRY_RE.search(self.trigger_details_html_url)
@@ -467,7 +467,7 @@ class Incident(Container):
         """
         if not user_ids:
             raise Error('Must pass at least one user id')
-        self._do_action('reassign', requester_id=requester_id, assigned_to_user=','.join(user_ids))
+        self._do_action('reassign', requester=requester_id, assigned_to_user=','.join(user_ids))
 
 
 class Note(Container):

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -452,15 +452,15 @@ class Incident(Container):
         self._do_action('acknowledged', requester=requester)
 
     def snooze(self, requester_id, duration):
-    # TODO: FIX THIS, GOES TO incidents/id/snooze, cant use _do_action as is.
+        # TODO: FIX THIS, GOES TO incidents/id/snooze, cant use _do_action as is.
         self._do_action('snooze', requester=requester_id, duration=duration)
 
     def get_trigger_log_entry(self, **kwargs):
         match = TRIGGER_LOG_ENTRY_RE.search(self.trigger_details_html_url)
         return self.log_entries.show(match.group('log_entry_id'), **kwargs)
 
-    # TODO: FIX THIS -- NO LONGER CAN USE _do_action
     def reassign(self, user_ids, requester_id):
+        # TODO: FIX THIS -- NO LONGER CAN USE _do_action
         """Reassign this incident to a user or list of users
 
         :param user_ids: A non-empty list of user ids

--- a/tests/incident_test.py
+++ b/tests/incident_test.py
@@ -65,7 +65,7 @@ def test_verb_action_v2():
         body=body2, status=200)
     p = pygerduty.v2.PagerDuty("password")
     incident1 = p.incidents.show('PT4KHLK')
-    incident1.acknowledge(requester_id='PXPGF42')
+    incident1.acknowledge(requester='eg@sample.com')
     incident2 = p.incidents.show('PT4KHLK')
 
     assert incident1.acknowledgements == []


### PR DESCRIPTION
Did not include requester_id in payload since I did not see it in the docs. Seems that it needs it as I got the following error in testing: 

```
  File "/home/khardson/.cache/bazel/_bazel_khardson/626bd8c1dab396de9d426ceb721ecbe3/execroot/server/bazel-out/local-fastbuild/bin/dropbox/jetstream/bin/slackbot.runfiles/__main__//dropbox/jetstream/bin/slackbot-piplib/pygerduty/v2.py", line 441, in _do_action
    return self.pagerduty.request('PUT', path, data=_json_dumper(data), extra_headers=extra_headers)
  File "/home/khardson/.cache/bazel/_bazel_khardson/626bd8c1dab396de9d426ceb721ecbe3/execroot/server/bazel-out/local-fastbuild/bin/dropbox/jetstream/bin/slackbot.runfiles/__main__//dropbox/jetstream/bin/slackbot-piplib/pygerduty/v2.py", line 631, in request
    return self.requester.execute_request(request)
  File "/home/khardson/.cache/bazel/_bazel_khardson/626bd8c1dab396de9d426ceb721ecbe3/execroot/server/bazel-out/local-fastbuild/bin/dropbox/jetstream/bin/slackbot.runfiles/__main__//dropbox/jetstream/bin/slackbot-piplib/pygerduty/common.py", line 56, in execute_request
    raise BadRequest(self.json_loader(err.read().decode("utf-8")))
BadRequest: Requester User Not Found (1008): []
```