### PR TITLE
Fixing bug on incident methods: snooze and reassign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+* `incidents/{id}/snooze` was not deprecated and requires old logic from `_do_action`. Fixed.
 
+### Added
+* `incidents/reassign` is a new endpoint, added logic for this.
+* Tests for the new incidents behavior.
 
 ## [0.36.2] - 2017-08-07
 

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -444,15 +444,21 @@ class Incident(Container):
         return hasattr(self.trigger_summary_data, 'subject')
 
     def resolve(self, requester):
-        # Takes email address of the requester.
+        """Resolve this incident.
+        :param requester: The email address of the individual acknowledging.
+        """
         self._do_action('resolved', requester=requester)
 
     def acknowledge(self, requester):
-        # Takes email address of the requester.
+        """Acknowledge this incident.
+        :param requester: The email address of the individual acknowledging.
+        """
         self._do_action('acknowledged', requester=requester)
 
     def snooze(self, requester, duration):
-        # Takes email address of the requester.
+        """Snooze incident.
+        :param requester: The email address of the individual requesting snooze.
+        """
         path = '{0}/{1}/{2}'.format(self.collection.name, self.id, 'snooze')
         data = {"duration": duration}
         extra_headers = {"From": requester}
@@ -466,6 +472,7 @@ class Incident(Container):
         """Reassign this incident to a user or list of users
 
         :param user_ids: A non-empty list of user ids
+        :param requester: The email address of individual requesting reassign
         """
         path = '{0}'.format(self.collection.name)
         assignments = []

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -488,15 +488,16 @@ class Incident(Container):
             assignments.append(ref)
         data = {
             "incidents": [
-              {
-                "id": self.id,
-                "type": "incident_reference",
-                "assignments": assignments
-              }
+                {
+                    "id": self.id,
+                    "type": "incident_reference",
+                    "assignments": assignments
+                }
             ]
         }
         extra_headers = {"From": requester}
         return self.pagerduty.request('PUT', path, data=_json_dumper(data), extra_headers=extra_headers)
+
 
 class Note(Container):
     pass

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -469,7 +469,6 @@ class Incident(Container):
         """
         path = '{0}'.format(self.collection.name)
         assignments = []
-
         if not user_ids:
             raise Error('Must pass at least one user id')
         for user_id in user_ids:
@@ -480,7 +479,6 @@ class Incident(Container):
                 }
             }
             assignments.append(ref)
-
         data = {
             "incidents": [
               {

--- a/tests/fixtures/incident_postassign.json
+++ b/tests/fixtures/incident_postassign.json
@@ -1,0 +1,110 @@
+{
+  "incident": {
+    "id": "PT4KHLK",
+    "type": "incident",
+    "summary": "[#1234] The server is on fire.",
+    "self": "https://api.pagerduty.com/incidents/PT4KHLK",
+    "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK",
+    "incident_number": 1234,
+    "created_at": "2015-10-06T21:30:42Z",
+    "status": "resolved",
+    "title": "The server is on fire.",
+    "resolve_reason": null,
+    "alert_counts": {
+      "all": 2,
+      "triggered": 0,
+      "resolved": 2
+    },
+    "pending_actions": [
+      {
+        "type": "unacknowledge",
+        "at": "2015-11-10T01:02:52Z"
+      },
+      {
+        "type": "resolve",
+        "at": "2015-11-10T04:31:52Z"
+      }
+    ],
+    "incident_key": "baf7cf21b1da41b4b0221008339ff357",
+    "service": {
+      "id": "PIJ90N7",
+      "type": "generic_email_reference",
+      "summary": "My Mail Service",
+      "self": "https://api.pagerduty.com/services/PIJ90N7",
+      "html_url": "https://subdomain.pagerduty.com/services/PIJ90N7"
+    },
+    "priority": {
+      "id": "P53ZZH5",
+      "type": "priority_reference",
+      "summary": "P2",
+      "self": "https://api.pagerduty.com/priorities/P53ZZH5",
+      "html_url": null
+    },
+    "assignments": [
+       {
+          "at": "2015-11-10T00:31:52Z",
+          "assignee": {
+            "id": "PXPGF42",
+            "type": "user_reference",
+            "summary": "Earline Greenholt",
+            "self": "https://api.pagerduty.com/users/PXPGF42",
+            "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
+          }
+        },
+        {
+          "at": "2015-11-10T00:32:32Z",
+          "assignee": {
+            "id": "PG23GSK",
+            "type": "user_reference",
+            "summary": "Vlad Green",
+            "self": "https://api.pagerduty.com/users/PG23GSK",
+            "html_url": "https://subdomain.pagerduty.com/users/PG23GSK"
+          }
+        }
+    ],
+    "acknowledgements": [
+      {
+        "at": "2015-11-10T00:32:52Z",
+        "acknowledger": {
+          "id": "PXPGF42",
+          "type": "user_reference",
+          "summary": "Earline Greenholt",
+          "self": "https://api.pagerduty.com/users/PXPGF42",
+          "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
+        }
+      }
+    ],
+    "last_status_change_at": "2015-10-06T21:38:23Z",
+    "last_status_change_by": {
+      "id": "PXPGF42",
+      "type": "user_reference",
+      "summary": "Earline Greenholt",
+      "self": "https://api.pagerduty.com/users/PXPGF42",
+      "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
+    },
+    "first_trigger_log_entry": {
+      "id": "Q02JTSNZWHSEKV",
+      "type": "trigger_log_entry_reference",
+      "summary": "Triggered through the API",
+      "self": "https://api.pagerduty.com/log_entries/Q02JTSNZWHSEKV?incident_id=PT4KHLK",
+      "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK/log_entries/Q02JTSNZWHSEKV"
+    },
+    "escalation_policy": {
+      "id": "PT20YPA",
+      "type": "escalation_policy_reference",
+      "summary": "Another Escalation Policy",
+      "self": "https://api.pagerduty.com/escalation_policies/PT20YPA",
+      "html_url": "https://subdomain.pagerduty.com/escalation_policies/PT20YPA"
+    },
+    "teams": [
+      {
+        "id": "PQ9K7I8",
+        "type": "team_reference",
+        "summary": "Engineering",
+        "self": "https://api.pagerduty.com/teams/PQ9K7I8",
+        "html_url": "https://subdomain.pagerduty.com/teams/PQ9K7I8"
+      }
+    ],
+    "urgency": "high"
+  }
+}

--- a/tests/fixtures/incident_preassign.json
+++ b/tests/fixtures/incident_preassign.json
@@ -1,0 +1,89 @@
+{
+  "incident": {
+    "id": "PT4KHLK",
+    "type": "incident",
+    "summary": "[#1234] The server is on fire.",
+    "self": "https://api.pagerduty.com/incidents/PT4KHLK",
+    "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK",
+    "incident_number": 1234,
+    "created_at": "2015-10-06T21:30:42Z",
+    "status": "resolved",
+    "title": "The server is on fire.",
+    "resolve_reason": null,
+    "alert_counts": {
+      "all": 2,
+      "triggered": 0,
+      "resolved": 2
+    },
+    "pending_actions": [
+      {
+        "type": "unacknowledge",
+        "at": "2015-11-10T01:02:52Z"
+      },
+      {
+        "type": "resolve",
+        "at": "2015-11-10T04:31:52Z"
+      }
+    ],
+    "incident_key": "baf7cf21b1da41b4b0221008339ff357",
+    "service": {
+      "id": "PIJ90N7",
+      "type": "generic_email_reference",
+      "summary": "My Mail Service",
+      "self": "https://api.pagerduty.com/services/PIJ90N7",
+      "html_url": "https://subdomain.pagerduty.com/services/PIJ90N7"
+    },
+    "priority": {
+      "id": "P53ZZH5",
+      "type": "priority_reference",
+      "summary": "P2",
+      "self": "https://api.pagerduty.com/priorities/P53ZZH5",
+      "html_url": null
+    },
+    "assignments": [],
+    "acknowledgements": [
+      {
+        "at": "2015-11-10T00:32:52Z",
+        "acknowledger": {
+          "id": "PXPGF42",
+          "type": "user_reference",
+          "summary": "Earline Greenholt",
+          "self": "https://api.pagerduty.com/users/PXPGF42",
+          "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
+        }
+      }
+    ],
+    "last_status_change_at": "2015-10-06T21:38:23Z",
+    "last_status_change_by": {
+      "id": "PXPGF42",
+      "type": "user_reference",
+      "summary": "Earline Greenholt",
+      "self": "https://api.pagerduty.com/users/PXPGF42",
+      "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
+    },
+    "first_trigger_log_entry": {
+      "id": "Q02JTSNZWHSEKV",
+      "type": "trigger_log_entry_reference",
+      "summary": "Triggered through the API",
+      "self": "https://api.pagerduty.com/log_entries/Q02JTSNZWHSEKV?incident_id=PT4KHLK",
+      "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK/log_entries/Q02JTSNZWHSEKV"
+    },
+    "escalation_policy": {
+      "id": "PT20YPA",
+      "type": "escalation_policy_reference",
+      "summary": "Another Escalation Policy",
+      "self": "https://api.pagerduty.com/escalation_policies/PT20YPA",
+      "html_url": "https://subdomain.pagerduty.com/escalation_policies/PT20YPA"
+    },
+    "teams": [
+      {
+        "id": "PQ9K7I8",
+        "type": "team_reference",
+        "summary": "Engineering",
+        "self": "https://api.pagerduty.com/teams/PQ9K7I8",
+        "html_url": "https://subdomain.pagerduty.com/teams/PQ9K7I8"
+      }
+    ],
+    "urgency": "high"
+  }
+}

--- a/tests/fixtures/incident_reassign.json
+++ b/tests/fixtures/incident_reassign.json
@@ -1,0 +1,105 @@
+{
+  "incidents": [
+    {
+      "id": "PT4KHLK",
+      "type": "incident",
+      "summary": "[#1234] The server is on fire.",
+      "self": "https://api.pagerduty.com/incidents/PT4KHLK",
+      "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK",
+      "incident_number": 1234,
+      "created_at": "2015-10-06T21:30:42Z",
+      "status": "resolved",
+      "title": "The server is on fire.",
+      "resolve_reason": null,
+      "alert_counts": {
+        "all": 2,
+        "triggered": 0,
+        "resolved": 2
+      },
+      "pending_actions": [
+        {
+          "type": "unacknowledge",
+          "at": "2015-11-10T01:02:52Z"
+        },
+        {
+          "type": "resolve",
+          "at": "2015-11-10T04:31:52Z"
+        }
+      ],
+      "incident_key": "baf7cf21b1da41b4b0221008339ff357",
+      "service": {
+        "id": "PIJ90N7",
+        "type": "generic_email",
+        "summary": "My Mail Service",
+        "self": "https://api.pagerduty.com/services/PIJ90N7",
+        "html_url": "https://subdomain.pagerduty.com/services/PIJ90N7"
+      },
+      "assignments": [
+        {
+          "at": "2015-11-10T00:31:52Z",
+          "assignee": {
+            "id": "PXPGF42",
+            "type": "user_reference",
+            "summary": "Earline Greenholt",
+            "self": "https://api.pagerduty.com/users/PXPGF42",
+            "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
+          }
+		},
+        {
+          "at": "2015-11-10T00:32:32Z",
+          "assignee": {
+            "id": "PG23GSK",
+            "type": "user_reference",
+            "summary": "Vlad Green",
+            "self": "https://api.pagerduty.com/users/PG23GSK",
+            "html_url": "https://subdomain.pagerduty.com/users/PG23GSK"
+          }
+        }
+      ],
+      "acknowledgements": [
+        {
+          "at": "2015-11-10T00:32:52Z",
+          "acknowledger": {
+            "id": "PXPGF42",
+            "type": "user_reference",
+            "summary": "Earline Greenholt",
+            "self": "https://api.pagerduty.com/users/PXPGF42",
+            "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
+          }
+        }
+      ],
+      "last_status_change_at": "2015-10-06T21:38:23Z",
+      "last_status_change_by": {
+        "id": "PXPGF42",
+        "type": "user_reference",
+        "summary": "Earline Greenholt",
+        "self": "https://api.pagerduty.com/users/PXPGF42",
+        "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
+      },
+      "first_trigger_log_entry": {
+        "id": "Q02JTSNZWHSEKV",
+        "type": "trigger_log_entry_reference",
+        "summary": "Triggered through the API",
+        "self": "https://api.pagerduty.com/log_entries/Q02JTSNZWHSEKV?incident_id=PT4KHLK",
+        "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK/log_entries/Q02JTSNZWHSEKV"
+      },
+      "escalation_policy": {
+        "id": "PT20YPA",
+        "type": "escalation_policy_reference",
+        "summary": "Another Escalation Policy",
+        "self": "https://api.pagerduty.com/escalation_policies/PT20YPA",
+        "html_url": "https://subdomain.pagerduty.com/escalation_policies/PT20YPA"
+      },
+      "teams": [
+        {
+          "id": "PQ9K7I8",
+          "type": "team_reference",
+          "summary": "Engineering",
+          "self": "https://api.pagerduty.com/teams/PQ9K7I8",
+          "html_url": "https://subdomain.pagerduty.com/teams/PQ9K7I8"
+        }
+      ],
+      "urgency": "high"
+    }
+  ]
+}

--- a/tests/fixtures/incident_snooze.json
+++ b/tests/fixtures/incident_snooze.json
@@ -1,0 +1,100 @@
+{
+  "incident": {
+    "id": "PT4KHLK",
+    "type": "incident",
+    "summary": "[#1234] The server is on fire.",
+    "self": "https://api.pagerduty.com/incidents/PT4KHLK",
+    "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK",
+    "incident_number": 1234,
+    "created_at": "2015-10-06T21:30:42Z",
+    "status": "resolved",
+    "title": "The server is on fire.",
+    "resolve_reason": null,
+    "alert_counts": {
+      "all": 2,
+      "triggered": 0,
+      "resolved": 2
+    },
+    "pending_actions": [
+      {
+        "type": "unacknowledge",
+        "at": "2015-11-10T01:02:52Z"
+      },
+      {
+        "type": "resolve",
+        "at": "2015-11-10T04:31:52Z"
+      }
+    ],
+    "incident_key": "baf7cf21b1da41b4b0221008339ff357",
+    "service": {
+      "id": "PIJ90N7",
+      "type": "generic_email_reference",
+      "summary": "My Mail Service",
+      "self": "https://api.pagerduty.com/services/PIJ90N7",
+      "html_url": "https://subdomain.pagerduty.com/services/PIJ90N7"
+    },
+    "priority": {
+      "id": "P53ZZH5",
+      "type": "priority_reference",
+      "summary": "P2",
+      "self": "https://api.pagerduty.com/priorities/P53ZZH5",
+      "html_url": null
+    },
+    "assignments": [
+      {
+        "at": "2015-11-10T00:31:52Z",
+        "assignee": {
+          "id": "PXPGF42",
+          "type": "user_reference",
+          "summary": "Earline Greenholt",
+          "self": "https://api.pagerduty.com/users/PXPGF42",
+          "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
+        }
+      }
+    ],
+    "acknowledgements": [
+      {
+        "at": "2015-11-10T00:32:52Z",
+        "acknowledger": {
+          "id": "PXPGF42",
+          "type": "user_reference",
+          "summary": "Earline Greenholt",
+          "self": "https://api.pagerduty.com/users/PXPGF42",
+          "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
+        }
+      }
+    ],
+    "last_status_change_at": "2015-10-06T21:38:23Z",
+    "last_status_change_by": {
+      "id": "PXPGF42",
+      "type": "user_reference",
+      "summary": "Earline Greenholt",
+      "self": "https://api.pagerduty.com/users/PXPGF42",
+      "html_url": "https://subdomain.pagerduty.com/users/PXPGF42"
+    },
+    "first_trigger_log_entry": {
+      "id": "Q02JTSNZWHSEKV",
+      "type": "trigger_log_entry_reference",
+      "summary": "Triggered through the API",
+      "self": "https://api.pagerduty.com/log_entries/Q02JTSNZWHSEKV?incident_id=PT4KHLK",
+      "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK/log_entries/Q02JTSNZWHSEKV"
+    },
+    "escalation_policy": {
+      "id": "PT20YPA",
+      "type": "escalation_policy_reference",
+      "summary": "Another Escalation Policy",
+      "self": "https://api.pagerduty.com/escalation_policies/PT20YPA",
+      "html_url": "https://subdomain.pagerduty.com/escalation_policies/PT20YPA"
+    },
+    "teams": [
+      {
+        "id": "PQ9K7I8",
+        "type": "team_reference",
+        "summary": "Engineering",
+        "self": "https://api.pagerduty.com/teams/PQ9K7I8",
+        "html_url": "https://subdomain.pagerduty.com/teams/PQ9K7I8"
+      }
+    ],
+    "urgency": "high"
+  }
+}

--- a/tests/incident_test.py
+++ b/tests/incident_test.py
@@ -100,21 +100,23 @@ def test_snooze_v2():
 
 @httpretty.activate
 def test_reassign_v2():
-    body1 = open('tests/fixtures/incident_get_v2.json').read()
-    body2 = open('tests/fixtures/incident_reassign.json').read()
+    body1 = open('tests/fixtures/incident_preassign.json').read()
+    body2 = open('tests/fixtures/incident_postassign.json').read()
     httpretty.register_uri(
         httpretty.GET, "https://api.pagerduty.com/incidents/PT4KHLK", responses=[
             httpretty.Response(body=body1, status=200),
             httpretty.Response(body=body2, status=200),
         ],
     )
+    body3 = open('tests/fixtures/incident_reassign.json').read()
     httpretty.register_uri(
         httpretty.PUT, 'https://api.pagerduty.com/incidents',
-        body=body2, status=200)
+        body=body3, status=200)
 
     p = pygerduty.v2.PagerDuty("password")
     incident1 = p.incidents.show('PT4KHLK')
     incident1.reassign(user_ids=['PXPGF42', 'PG23GSK'], requester='test@dropbox.com')
     incident2 = p.incidents.show('PT4KHLK')
 
-    assert len(incident2.incidents[0].assignments) == 2
+    assert len(incident1.assignments) == 0
+    assert len(incident2.assignments) == 2

--- a/tests/incident_test.py
+++ b/tests/incident_test.py
@@ -70,3 +70,51 @@ def test_verb_action_v2():
 
     assert incident1.acknowledgements == []
     assert incident2.acknowledgements[0].acknowledger.id == 'PXPGF42'
+
+
+@httpretty.activate
+def test_snooze_v2():
+    body1 = open('tests/fixtures/incident_get_v2.json').read()
+    body2 = open('tests/fixtures/incident_snooze.json').read()
+    httpretty.register_uri(
+        httpretty.GET, "https://api.pagerduty.com/incidents/PT4KHLK", responses=[
+            httpretty.Response(body=body1, status=200),
+            httpretty.Response(body=body2, status=200),
+        ],
+    )
+
+    httpretty.register_uri(
+        httpretty.POST, 'https://api.pagerduty.com/incidents/PT4KHLK/snooze',
+        body=body2, status=200)
+
+    p = pygerduty.v2.PagerDuty("password")
+    incident1 = p.incidents.show('PT4KHLK')
+    incident1.snooze(requester='test@dropbox.com', duration=2000)
+    incident2 = p.incidents.show('PT4KHLK')
+
+    assert incident2.self_ == "https://api.pagerduty.com/incidents/PT4KHLK"
+    assert len(incident2.pending_actions) == 2
+    assert incident2.service.type == 'generic_email_reference'
+    assert len(incident2.assignments) == 1
+
+
+@httpretty.activate
+def test_reassign_v2():
+    body1 = open('tests/fixtures/incident_get_v2.json').read()
+    body2 = open('tests/fixtures/incident_reassign.json').read()
+    httpretty.register_uri(
+        httpretty.GET, "https://api.pagerduty.com/incidents/PT4KHLK", responses=[
+            httpretty.Response(body=body1, status=200),
+            httpretty.Response(body=body2, status=200),
+        ],
+    )
+    httpretty.register_uri(
+        httpretty.PUT, 'https://api.pagerduty.com/incidents',
+        body=body2, status=200)
+
+    p = pygerduty.v2.PagerDuty("password")
+    incident1 = p.incidents.show('PT4KHLK')
+    incident1.reassign(user_ids=['PXPGF42', 'PG23GSK'], requester='test@dropbox.com')
+    incident2 = p.incidents.show('PT4KHLK')
+
+    assert len(incident2.incidents[0].assignments) == 2


### PR DESCRIPTION
Pagerduty API v2 has changed the way it snoozes and reassigns incidents. I have updated these functions to reflect this and added two tests. 