### PR TITLE
Remove py3.3 from travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 # Keep in-sync with tox.ini.
 env:
     - TOXENV=py27
-    - TOXENV=py33
     - TOXENV=py34
 
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 project = pygerduty
 
 # Keep in-sync with .travis.yml.
-envlist = py27,py33,py34
+envlist = py27,py34
 
 [testenv]
 install_command = pip install --use-wheel {opts} {packages}


### PR DESCRIPTION
Unable to get 3.3 working on travis at the moment, just kill it for now.
We still have 3.4 checking