### PR TITLE
Removing `has_subject` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Fixed
 * `incidents/{id}/snooze` was not deprecated and requires old logic from `_do_action`. Fixed.
-
+* `trigger_summary_data` attribute was removed from incident response, removed `has_subject` function which referenced this.
 ### Added
 * `incidents/reassign` is a new endpoint, added logic for this.
 * Tests for the new incidents behavior.
@@ -15,10 +15,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [0.36.3] - 2017-08-10
 
 ### Fixed
-- Bug with Incident.ack/resolve. The should now work.
+- Bug with Incident.ack/resolve. This should now work.
 
 ### Changed
-- Renamed requestor_id to requestor to make it more clear you pass an e-mail now instead of user id on various Incident methods
+- Renamed requester_id to requester to make it more clear you pass an e-mail now instead of user id on various Incident methods.
 
 ## [0.36.2] - 2017-08-07
 

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -440,9 +440,6 @@ class Incident(Container):
         extra_headers = {'From': requester}
         return self.pagerduty.request('PUT', path, data=_json_dumper(data), extra_headers=extra_headers)
 
-    def has_subject(self):
-        return hasattr(self.trigger_summary_data, 'subject')
-
     def resolve(self, requester):
         """Resolve this incident.
         :param requester: The email address of the individual acknowledging.


### PR DESCRIPTION
The `has_subject` method references an attribute that has been removed from the incident response with API v2. I have removed this method from the library.