### PR TITLE
LogEntries default to adding include[]=channels for custom details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 * `incidents/reassign` is a new endpoint, added logic for this.
 * Tests for the new incidents behavior.
+* LogEntries default to adding include[]=channels for list and show to get "custom details".
 
 ## [0.36.3] - 2017-08-10
 

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -119,8 +119,6 @@ class Collection(object):
             if k not in kwargs:
                 kwargs[k] = v
         return kwargs
-                kwargs[k] = v
-        return kwargs
 
     def update(self, entity_id, **kwargs):
         path = "{0}/{1}".format(self.name, entity_id)

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -48,6 +48,7 @@ class NotFound(Error):
 
 class Collection(object):
     paginated = True
+    default_query_params = {}
 
     def __init__(self, pagerduty, base_container=None):
         self.name = getattr(self, "name", False) or _lower(self.__class__.__name__)
@@ -113,6 +114,14 @@ class Collection(object):
             new_kwargs.append(new_kwarg)
         return new_kwargs
 
+    def _apply_default_kwargs(self, kwargs):
+        for k, v in self.default_query_params.iteritems():
+            if k not in kwargs:
+                kwargs[k] = v
+        return kwargs
+                kwargs[k] = v
+        return kwargs
+
     def update(self, entity_id, **kwargs):
         path = "{0}/{1}".format(self.name, entity_id)
         if self.base_container:
@@ -154,6 +163,7 @@ class Collection(object):
         return self._list_response(response)
 
     def list(self, **kwargs):
+        kwargs = self._apply_default_kwargs(kwargs)
         # Some APIs are paginated. If they are, and the user isn't doing
         # pagination themselves, let's do it for them
         if not self.paginated or any(key in kwargs for key in ('offset', 'limit')):
@@ -194,6 +204,7 @@ class Collection(object):
         return response.get("total", None)
 
     def show(self, entity_id, **kwargs):
+        kwargs = self._apply_default_kwargs(kwargs)
         path = "{0}/{1}".format(self.name, entity_id)
         if self.base_container:
             path = "{0}/{1}/{2}/{3}".format(
@@ -329,7 +340,8 @@ class EmailFilters(Collection):
 
 
 class LogEntries(Collection):
-    pass
+    # https://support.pagerduty.com/v1/docs/retrieve-trigger-event-data-using-the-api#section-how-to-obtain-the-data  # noqa
+    default_query_params = {'include': ['channels']}
 
 
 class Notes(Collection):

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -115,7 +115,7 @@ class Collection(object):
         return new_kwargs
 
     def _apply_default_kwargs(self, kwargs):
-        for k, v in self.default_query_params.iteritems():
+        for k, v in self.default_query_params.items():
             if k not in kwargs:
                 kwargs[k] = v
         return kwargs


### PR DESCRIPTION
as per https://support.pagerduty.com/v1/docs/retrieve-trigger-event-data-using-the-api#section-how-to-obtain-the-data
one must now specify `include[]=channels` to get everything that was
passed to pagerduty when the incident was created, e.g. "custom details"