### PR TITLE
add extensions collection to v2 client

### DIFF
--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -337,6 +337,10 @@ class EmailFilters(Collection):
     pass
 
 
+class Extensions(Collection):
+    pass
+
+
 class LogEntries(Collection):
     # https://support.pagerduty.com/v1/docs/retrieve-trigger-event-data-using-the-api#section-how-to-obtain-the-data  # noqa
     default_query_params = {'include': ['channels']}
@@ -431,6 +435,10 @@ class Container(object):
             else:
                 json_dict[key] = value
         return json_dict
+
+
+class Extension(Container):
+    pass
 
 
 class Incident(Container):
@@ -628,6 +636,7 @@ class PagerDuty(object):
         self.maintenance_windows = MaintenanceWindows(self)
         self.teams = Teams(self)
         self.log_entries = LogEntries(self)
+        self.extensions = Extensions(self)
 
     @staticmethod
     def _process_query_params(query_params):

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ project = pygerduty
 envlist = py27,py34
 
 [testenv]
-install_command = pip install --use-wheel {opts} {packages}
+install_command = pip install {opts} {packages}
 deps = flake8
 commands =
     flake8 {[tox]project} setup.py


### PR DESCRIPTION
Add a collection for the extensions endpoint: https://v2.developer.pagerduty.com/v2/page/api-reference#!/Extensions/get_extensions

Not sure what tests to add, but I checked:

```
Python 3.6.5 (default, Jun  6 2018, 00:52:57)
[GCC 7.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pygerduty.v2
>>> import os
>>> PD_RO_KEY = os.environ.get("pagerdutyRoKey", None)
>>> client = pygerduty.v2.PagerDuty(PD_RO_KEY)
>>> next(client.extensions.list())
<Extension: endpoint_url='https://<>.execute-api.us-east-1.amazonaws.com/api/<>/', name='pagerstatus', config=<Container: >, extension_schema=<Container: id='<>', type='extension_schema_reference', summary='Generic V2 Webhook', ...
```