### PR TITLE
Cleanup Oncalls and add Tests

### DIFF
--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -184,10 +184,6 @@ class Collection(object):
                     break
 
                 for item in this_paginated_result:
-                    # add items to seen_items only if id is present in response
-                    # oncalls does not have a id in response
-                    if not hasattr(item, 'id'):
-                        continue
                     if item.id in seen_items:
                         continue
                     seen_items.add(item.id)
@@ -346,15 +342,7 @@ class Extensions(Collection):
 
 
 class Oncalls(Collection):
-    sname = 'Oncall'
-
-    def show(self, **kwargs):
-        kwargs = self._apply_default_kwargs(kwargs)
-        path = self.name
-        response = self.pagerduty.request(
-            "GET", path, query_params=kwargs)
-
-        return self.container(self, **response)
+    pass
 
 
 class LogEntries(Collection):
@@ -458,7 +446,11 @@ class Extension(Container):
 
 
 class Oncall(Container):
-    pass
+    def __init__(self, *args, **kwargs):
+        Container.__init__(self, *args, **kwargs)
+        self.id = '%s:%s:%s' % (self.user.id,
+                                self.schedule.id,
+                                self.escalation_policy.id)
 
 
 class Incident(Container):

--- a/tests/extensions_test.py
+++ b/tests/extensions_test.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import
+
+import httpretty
+import pygerduty.v2
+import textwrap
+
+###################
+# Version 2 Tests #
+###################
+
+
+@httpretty.activate
+def test_get_extension_v2():
+    body = open('tests/fixtures/get_extension_v2.json').read()
+    httpretty.register_uri(
+        httpretty.GET, "https://api.pagerduty.com/extensions/PPGPXHO",
+        body=body, status=200)
+    p = pygerduty.v2.PagerDuty("password")
+    extension = p.extensions.show("PPGPXHO")
+
+    assert extension.self_ == 'https://api.pagerduty.com/extensions/PPGPXHO'
+    assert extension.endpoint_url == 'https://example.com/recieve_a_pagerduty_webhook'
+    assert len(extension.extension_objects) == 1
+    ext_obj = extension.extension_objects[0]
+    assert ext_obj.id == 'PIJ90N7'
+
+
+@httpretty.activate
+def test_list_extensions_v2():
+    body = open('tests/fixtures/extensions_list_v2.json').read()
+    httpretty.register_uri(
+        httpretty.GET, "https://api.pagerduty.com/extensions", responses=[
+            httpretty.Response(body=body, status=200),
+            httpretty.Response(body=textwrap.dedent("""\
+                {
+                    "limit": 25,
+                    "more": false,
+                    "offset": 1,
+                    "extensions": [],
+                    "total": null
+                }
+            """), status=200),
+        ],
+    )
+
+    p = pygerduty.v2.PagerDuty("password")
+    extensions = [s for s in p.extensions.list()]
+
+    assert len(extensions) == 2
+    assert extensions[0].self_ == 'https://api.pagerduty.com/extensions/PPGPXHO'
+    assert extensions[0].endpoint_url == 'https://example.com/recieve_a_pagerduty_webhook'
+    assert len(extensions[0].extension_objects) == 1
+    ext_obj0 = extensions[0].extension_objects[0]
+    assert ext_obj0.id == 'PIJ90N7'
+
+    assert extensions[1].self_ == 'https://api.pagerduty.com/extensions/PPGPXHI'
+    assert extensions[1].endpoint_url == 'https://example.com/recieve_a_pagerduty_webhook_2'
+    assert len(extensions[1].extension_objects) == 1
+    ext_obj1 = extensions[1].extension_objects[0]
+    assert ext_obj1.id == 'PIJ90N8'

--- a/tests/fixtures/extensions_list_v2.json
+++ b/tests/fixtures/extensions_list_v2.json
@@ -1,0 +1,58 @@
+{
+  "extensions": [
+    {
+      "id": "PPGPXHO",
+      "self": "https://api.pagerduty.com/extensions/PPGPXHO",
+      "html_url": null,
+      "endpoint_url": "https://example.com/recieve_a_pagerduty_webhook",
+      "name": "My Webhook",
+      "summary": "My Webhook",
+      "type": "extension",
+      "extension_schema": {
+        "id": "PJFWPEP",
+        "type": "extension_schema_reference",
+        "summary": "Generic Webhook",
+        "self": "https://api.pagerduty.com/extension_schemas/PJFWPEP",
+        "html_url": null
+      },
+      "extension_objects": [
+        {
+          "id": "PIJ90N7",
+          "type": "service_reference",
+          "summary": "My Application Service",
+          "self": "https://api.pagerduty.com/services/PIJ90N7",
+          "html_url": "https://subdomain.pagerduty.com/services/PIJ90N7"
+        }
+      ]
+    },
+    {
+      "id": "PPGPXHI",
+      "self": "https://api.pagerduty.com/extensions/PPGPXHI",
+      "html_url": null,
+      "endpoint_url": "https://example.com/recieve_a_pagerduty_webhook_2",
+      "name": "My Webhook 2",
+      "summary": "My Webhook w",
+      "type": "extension",
+      "extension_schema": {
+        "id": "PJFWPEP",
+        "type": "extension_schema_reference",
+        "summary": "Generic Webhook",
+        "self": "https://api.pagerduty.com/extension_schemas/PJFWPEP",
+        "html_url": null
+      },
+      "extension_objects": [
+        {
+          "id": "PIJ90N8",
+          "type": "service_reference",
+          "summary": "My Application Service",
+          "self": "https://api.pagerduty.com/services/PIJ90N8",
+          "html_url": "https://subdomain.pagerduty.com/services/PIJ90N8"
+        }
+      ]
+    }
+  ],
+  "limit": 25,
+  "offset": 0,
+  "total": null,
+  "more": false
+}

--- a/tests/fixtures/get_extension_v2.json
+++ b/tests/fixtures/get_extension_v2.json
@@ -1,0 +1,27 @@
+{
+  "extension": {
+    "id": "PPGPXHO",
+    "self": "https://api.pagerduty.com/extensions/PPGPXHO",
+    "html_url": null,
+    "endpoint_url": "https://example.com/recieve_a_pagerduty_webhook",
+    "name": "My Webhook",
+    "summary": "My Webhook",
+    "type": "extension",
+    "extension_schema": {
+      "id": "PJFWPEP",
+      "type": "extension_schema_reference",
+      "summary": "Generic Webhook",
+      "self": "https://api.pagerduty.com/extension_schemas/PJFWPEP",
+      "html_url": null
+    },
+    "extension_objects": [
+      {
+        "id": "PIJ90N7",
+        "type": "service_reference",
+        "summary": "My Application Service",
+        "self": "https://api.pagerduty.com/services/PIJ90N7",
+        "html_url": "https://subdomain.pagerduty.com/services/PIJ90N7"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/oncalls_filtered_v2.json
+++ b/tests/fixtures/oncalls_filtered_v2.json
@@ -1,0 +1,34 @@
+{
+  "oncalls": [
+    {
+      "user": {
+        "id": "PT23IWX",
+        "type": "user_reference",
+        "summary": "Tim Wright",
+        "self": "https://api.pagerduty.com/users/PT23IWX",
+        "html_url": "https://subdomain.pagerduty.com/users/PT23IWX"
+      },
+      "schedule": {
+        "id": "PI7DH85",
+        "type": "schedule_reference",
+        "summary": "Daily Engineering Rotation",
+        "self": "https://api.pagerduty.com/schedules/PI7DH85",
+        "html_url": "https://subdomain.pagerduty.com/schedules/PI7DH85"
+      },
+      "escalation_policy": {
+        "id": "PT20YPA",
+        "type": "escalation_policy_reference",
+        "summary": "Engineering Escalation Policy",
+        "self": "https://api.pagerduty.com/escalation_policies/PT20YPA",
+        "html_url": "https://subdomain.pagerduty.com/escalation_policies/PT20YPA"
+      },
+      "escalation_level": 2,
+      "start": "2015-03-06T15:28:51-05:00",
+      "end": "2015-03-07T15:28:51-05:00"
+    }
+  ],
+  "limit": 25,
+  "offset": 0,
+  "more": false,
+  "total": null
+}

--- a/tests/fixtures/oncalls_list_v2.json
+++ b/tests/fixtures/oncalls_list_v2.json
@@ -1,0 +1,60 @@
+{
+  "oncalls": [
+    {
+      "user": {
+        "id": "PT23IWX",
+        "type": "user_reference",
+        "summary": "Tim Wright",
+        "self": "https://api.pagerduty.com/users/PT23IWX",
+        "html_url": "https://subdomain.pagerduty.com/users/PT23IWX"
+      },
+      "schedule": {
+        "id": "PI7DH85",
+        "type": "schedule_reference",
+        "summary": "Daily Engineering Rotation",
+        "self": "https://api.pagerduty.com/schedules/PI7DH85",
+        "html_url": "https://subdomain.pagerduty.com/schedules/PI7DH85"
+      },
+      "escalation_policy": {
+        "id": "PT20YPA",
+        "type": "escalation_policy_reference",
+        "summary": "Engineering Escalation Policy",
+        "self": "https://api.pagerduty.com/escalation_policies/PT20YPA",
+        "html_url": "https://subdomain.pagerduty.com/escalation_policies/PT20YPA"
+      },
+      "escalation_level": 2,
+      "start": "2015-03-06T15:28:51-05:00",
+      "end": "2015-03-07T15:28:51-05:00"
+    },
+    {
+      "user": {
+        "id": "PT23IEW",
+        "type": "user_reference",
+        "summary": "Tim Wrong",
+        "self": "https://api.pagerduty.com/users/PT23IEW",
+        "html_url": "https://subdomain.pagerduty.com/users/PT23IEW"
+      },
+      "schedule": {
+        "id": "PI7DD43",
+        "type": "schedule_reference",
+        "summary": "Daily Engineering Rotation",
+        "self": "https://api.pagerduty.com/schedules/PI7DD43",
+        "html_url": "https://subdomain.pagerduty.com/schedules/PI7DD43"
+      },
+      "escalation_policy": {
+        "id": "PT20YPB",
+        "type": "escalation_policy_reference",
+        "summary": "Engineering Escalation Policy",
+        "self": "https://api.pagerduty.com/escalation_policies/PT20YPB",
+        "html_url": "https://subdomain.pagerduty.com/escalation_policies/PT20YPB"
+      },
+      "escalation_level": 2,
+      "start": "2015-03-06T15:28:51-05:00",
+      "end": "2015-05-07T15:28:51-05:00"
+    }
+  ],
+  "limit": 25,
+  "offset": 0,
+  "more": false,
+  "total": null
+}

--- a/tests/oncalls_test.py
+++ b/tests/oncalls_test.py
@@ -1,0 +1,81 @@
+from __future__ import absolute_import
+
+import httpretty
+import pygerduty.v2
+import textwrap
+
+###################
+# Version 2 Tests #
+###################
+
+
+@httpretty.activate
+def test_list_oncalls_v2():
+    body = open('tests/fixtures/oncalls_list_v2.json').read()
+    httpretty.register_uri(
+        httpretty.GET, "https://api.pagerduty.com/oncalls", responses=[
+            httpretty.Response(body=body, status=200),
+            httpretty.Response(body=textwrap.dedent("""\
+                {
+                    "limit": 25,
+                    "more": false,
+                    "offset": 1,
+                    "oncalls": [],
+                    "total": null
+                }
+            """), status=200),
+        ],
+    )
+
+    p = pygerduty.v2.PagerDuty("password")
+    oncalls = [s for s in p.oncalls.list()]
+
+    assert len(oncalls) == 2
+    assert oncalls[0].user.type == 'user_reference'
+    assert oncalls[0].user.self_ == 'https://api.pagerduty.com/users/PT23IWX'
+    assert oncalls[0].schedule.type == 'schedule_reference'
+    assert oncalls[0].schedule.self_ == 'https://api.pagerduty.com/schedules/PI7DH85'
+    assert oncalls[0].escalation_policy.type == 'escalation_policy_reference'
+    assert oncalls[0].escalation_policy.self_ == 'https://api.pagerduty.com/escalation_policies/PT20YPA'
+    assert oncalls[0].start == '2015-03-06T15:28:51-05:00'
+    assert oncalls[0].end == '2015-03-07T15:28:51-05:00'
+
+    assert oncalls[1].user.type == 'user_reference'
+    assert oncalls[1].user.self_ == 'https://api.pagerduty.com/users/PT23IEW'
+    assert oncalls[1].schedule.type == 'schedule_reference'
+    assert oncalls[1].schedule.self_ == 'https://api.pagerduty.com/schedules/PI7DD43'
+    assert oncalls[1].escalation_policy.type == 'escalation_policy_reference'
+    assert oncalls[1].escalation_policy.self_ == 'https://api.pagerduty.com/escalation_policies/PT20YPB'
+    assert oncalls[1].start == '2015-03-06T15:28:51-05:00'
+    assert oncalls[1].end == '2015-05-07T15:28:51-05:00'
+
+@httpretty.activate
+def test_list_oncalls_filtered_v2():
+    body = open('tests/fixtures/oncalls_filtered_v2.json').read()
+    httpretty.register_uri(
+        httpretty.GET, "https://api.pagerduty.com/oncalls", responses=[
+            httpretty.Response(body=body, status=200),
+            httpretty.Response(body=textwrap.dedent("""\
+                {
+                    "limit": 25,
+                    "more": false,
+                    "offset": 1,
+                    "oncalls": [],
+                    "total": null
+                }
+            """), status=200),
+        ],
+    )
+
+    p = pygerduty.v2.PagerDuty("password")
+    oncalls = [s for s in p.oncalls.list(schedule_ids=['PI7DH85'])]
+
+    assert len(oncalls) == 1
+    assert oncalls[0].user.type == 'user_reference'
+    assert oncalls[0].user.self_ == 'https://api.pagerduty.com/users/PT23IWX'
+    assert oncalls[0].schedule.type == 'schedule_reference'
+    assert oncalls[0].schedule.self_ == 'https://api.pagerduty.com/schedules/PI7DH85'
+    assert oncalls[0].escalation_policy.type == 'escalation_policy_reference'
+    assert oncalls[0].escalation_policy.self_ == 'https://api.pagerduty.com/escalation_policies/PT20YPA'
+    assert oncalls[0].start == '2015-03-06T15:28:51-05:00'
+    assert oncalls[0].end == '2015-03-07T15:28:51-05:00'


### PR DESCRIPTION
Added a unique id to the oncall container which ensures `list` works
with the Collection implemented pagination logic (requires an id).

Removed the overridden `show()` method which is inconsistent with how
show works on other objects (the `oncalls` endpoint does not support
getting a single oncall, as there is no PagerDuty id for them).

Also tested that filtering with `oncalls.list()` works (for example `oncalls.list(schedule_ids=['<id>']`).

I also added some tests for the `extensions` and `oncalls` objects. I don't think the `extensions` tests are exhaustive yet, but it's a start. Likely needs more work to ensure create/updating extensions works.