### PR TITLE
Adding support for Addons

### DIFF
--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -53,8 +53,7 @@ class Collection(object):
     def __init__(self, pagerduty, base_container=None):
         self.name = getattr(self, "name", False) or _lower(self.__class__.__name__)
         self.sname = getattr(self, "sname", False) or _singularize(self.name)
-        self.container = (getattr(self, "container", False) or
-                          globals()[_upper(self.sname)])
+        self.container = (getattr(self, "container", False) or globals()[_upper(self.sname)])
 
         self.pagerduty = pagerduty
         self.base_container = base_container

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -341,6 +341,10 @@ class Extensions(Collection):
     pass
 
 
+class Addons(Collection):
+    pass
+
+
 class Oncalls(Collection):
     pass
 
@@ -444,6 +448,8 @@ class Container(object):
 class Extension(Container):
     pass
 
+class Addon(Container):
+    pass
 
 class Oncall(Container):
     def __init__(self, *args, **kwargs):
@@ -649,6 +655,7 @@ class PagerDuty(object):
         self.teams = Teams(self)
         self.log_entries = LogEntries(self)
         self.extensions = Extensions(self)
+        self.addons = Addons(self)
         self.oncalls = Oncalls(self)
 
     @staticmethod

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -53,7 +53,8 @@ class Collection(object):
     def __init__(self, pagerduty, base_container=None):
         self.name = getattr(self, "name", False) or _lower(self.__class__.__name__)
         self.sname = getattr(self, "sname", False) or _singularize(self.name)
-        self.container = (getattr(self, "container", False) or globals()[_upper(self.sname)])
+        self.container = (getattr(self, "container", False) or
+                          globals()[_upper(self.sname)])
 
         self.pagerduty = pagerduty
         self.base_container = base_container

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -448,8 +448,10 @@ class Container(object):
 class Extension(Container):
     pass
 
+
 class Addon(Container):
     pass
+
 
 class Oncall(Container):
     def __init__(self, *args, **kwargs):

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -450,7 +450,14 @@ class Extension(Container):
 
 
 class Addon(Container):
-    pass
+    def install(self, *args, **kwargs):
+        raise NotImplementedError()
+
+    def delete(self, *args, **kwargs):
+        raise NotImplementedError()
+
+    def list(self, *args, **kwargs):
+        raise NotImplementedError()
 
 
 class Oncall(Container):

--- a/tests/addon_test.py
+++ b/tests/addon_test.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import
+
+import httpretty
+import pygerduty
+import pygerduty.v2
+
+
+###################
+# Version 2 Tests #
+###################
+
+@httpretty.activate
+def test_get_addon_v2():
+    body = open('tests/fixtures/addon_v2.json').read()
+    httpretty.register_uri(
+        httpretty.GET, "https://api.pagerduty.com/addons/PKX7F81",
+        body=body, status=200)
+
+    p = pygerduty.v2.PagerDuty("password")
+    addon = p.addons.show("PKX7F81")
+
+    assert addon.id == "PKX7F81"
+    assert addon.type == "incident_show_addon"
+    assert addon.name == "Service Runbook"
+    assert addon.src == "https://intranet.example.com/runbook.html"
+    assert addon.services[0].id == "PIJ90N7"
+
+@httpretty.activate
+def test_update_addon_v2():
+    body_req = open('tests/fixtures/addon_update_request_v2.json').read()
+    body_resp = open('tests/fixtures/addon_update_response_v2.json').read()
+    httpretty.register_uri(
+        httpretty.PUT, "https://api.pagerduty.com/addons/PKX7F81",
+        body=body_req,
+        responses=[httpretty.Response(body=body_resp, status=200)])
+
+    p = pygerduty.v2.PagerDuty("password")
+    addon = p.addons.update("PKX7F81")
+
+    assert addon.id == "PKX7F81"
+    assert addon.type == "incident_show_addon"
+    assert addon.name == "Service Runbook"
+    assert addon.src == "https://intranet.example.com/runbook.html"
+    assert addon.services[0].id == "PIJ90N7"

--- a/tests/fixtures/addon_update_request_v2.json
+++ b/tests/fixtures/addon_update_request_v2.json
@@ -1,0 +1,7 @@
+{
+    "addon": {
+        "type": "full_page_addon",
+        "name": "Service Runbook",
+        "src": "https://intranet.example.com/runbook.html"
+    }
+}

--- a/tests/fixtures/addon_update_response_v2.json
+++ b/tests/fixtures/addon_update_response_v2.json
@@ -1,0 +1,17 @@
+{
+    "addon": {
+        "id": "PKX7F81",
+        "type": "incident_show_addon",
+        "name": "Service Runbook",
+        "src": "https://intranet.example.com/runbook.html",
+        "services": [
+            {
+                "id": "PIJ90N7",
+                "type": "service",
+                "summary": "My Application Service",
+                "self": "https://api.pagerduty.com/services/PIJ90N7",
+                "html_url": "https://subdomain.pagerduty.com/services/PIJ90N7"
+            }
+        ]
+    }
+}

--- a/tests/fixtures/addon_v2.json
+++ b/tests/fixtures/addon_v2.json
@@ -1,0 +1,17 @@
+{
+    "addon": {
+        "id": "PKX7F81",
+        "type": "incident_show_addon",
+        "name": "Service Runbook",
+        "src": "https://intranet.example.com/runbook.html",
+        "services": [
+            {
+                "id": "PIJ90N7",
+                "type": "service",
+                "summary": "My Application Service",
+                "self": "https://api.pagerduty.com/services/PIJ90N7",
+                "html_url": "https://subdomain.pagerduty.com/services/PIJ90N7"
+            }
+        ]
+    }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ commands =
     {envpython} setup.py test
 
 [flake8]
-ignore = E265,E309,E501
+ignore = E265,E309,E501,W504


### PR DESCRIPTION
This simple change allows to update Add-ons. Tested with:
```
client = pygerduty.v2.PagerDuty(pagerduty_api_token)
my_addon = client.addons.show(addon_id)
service_ref = [ { "type": "service_reference", "id":service_id } ]
client.addons.update(my_addon.id,services=service_ref)
```