### PR TITLE
Support optional fields in oncalls object

### DIFF
--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -63,8 +63,8 @@ class Collection(object):
     def __init__(self, pagerduty, base_container=None):
         self.name = getattr(self, "name", False) or _lower(self.__class__.__name__)
         self.sname = getattr(self, "sname", False) or _singularize(self.name)
-        self.container = (getattr(self, "container", False) or
-                          globals()[_upper(self.sname)])
+        self.container = (
+            getattr(self, "container", False) or globals()[_upper(self.sname)])
 
         self.pagerduty = pagerduty
         self.base_container = base_container

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -53,8 +53,8 @@ class Collection(object):
     def __init__(self, pagerduty, base_container=None):
         self.name = getattr(self, "name", False) or _lower(self.__class__.__name__)
         self.sname = getattr(self, "sname", False) or _singularize(self.name)
-        self.container = (getattr(self, "container", False) or
-                          globals()[_upper(self.sname)])
+        self.container = (
+            getattr(self, "container", False) or globals()[_upper(self.sname)])
 
         self.pagerduty = pagerduty
         self.base_container = base_container
@@ -448,9 +448,9 @@ class Extension(Container):
 class Oncall(Container):
     def __init__(self, *args, **kwargs):
         Container.__init__(self, *args, **kwargs)
-        self.id = '%s:%s:%s' % (self.user.id,
-                                self.schedule.id,
-                                self.escalation_policy.id)
+        self.id = '%s:%s:%s' % (self.user.id if self.user else '',
+                                self.schedule.id if self.schedule else '',
+                                self.escalation_policy.id if self.escalation_policy else '')
 
 
 class Incident(Container):

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -448,9 +448,11 @@ class Extension(Container):
 class Oncall(Container):
     def __init__(self, *args, **kwargs):
         Container.__init__(self, *args, **kwargs)
-        self.id = '%s:%s:%s' % (self.user.id if self.user else '',
-                                self.schedule.id if self.schedule else '',
-                                self.escalation_policy.id if self.escalation_policy else '')
+        self.id = '%s:%s:%s' % (self.user.id if hasattr(self, 'user') and self.user else '',
+                                self.schedule.id if hasattr(
+                                    self, 'schedule') and self.schedule else '',
+                                self.escalation_policy.id if hasattr(
+                                    self, 'escalation_policy') and self.escalation_policy else '')
 
 
 class Incident(Container):

--- a/pygerduty/version.py
+++ b/pygerduty/version.py
@@ -1,2 +1,2 @@
-version_info = (0, 38, 0)
+version_info = (0, 38, 1)
 __version__ = '.'.join(str(v) for v in version_info)

--- a/tests/oncalls_test.py
+++ b/tests/oncalls_test.py
@@ -79,3 +79,28 @@ def test_list_oncalls_filtered_v2():
     assert oncalls[0].escalation_policy.self_ == 'https://api.pagerduty.com/escalation_policies/PT20YPA'
     assert oncalls[0].start == '2015-03-06T15:28:51-05:00'
     assert oncalls[0].end == '2015-03-07T15:28:51-05:00'
+
+def test_oncall_ids():
+    p = pygerduty.v2.PagerDuty("password")
+    collection = pygerduty.v2.Collection(p)
+
+    oncall = pygerduty.v2.Oncall(
+            collection=collection,
+            user=None,
+            schedule={'id': 'schedule'},
+            escalation_policy={'id': 'escalation_policy'})
+    assert oncall.id == ':schedule:escalation_policy'
+
+    oncall = pygerduty.v2.Oncall(
+            collection=collection,
+            user={'id': 'user'},
+            schedule=None,
+            escalation_policy={'id': 'escalation_policy'})
+    assert oncall.id == 'user::escalation_policy'
+
+    oncall = pygerduty.v2.Oncall(
+            collection=collection,
+            user={'id': 'user'},
+            schedule={'id': 'schedule'},
+            escalation_policy=None)
+    assert oncall.id == 'user:schedule:'

--- a/tests/oncalls_test.py
+++ b/tests/oncalls_test.py
@@ -104,3 +104,21 @@ def test_oncall_ids():
             schedule={'id': 'schedule'},
             escalation_policy=None)
     assert oncall.id == 'user:schedule:'
+
+    oncall = pygerduty.v2.Oncall(
+            collection=collection,
+            schedule={'id': 'schedule'},
+            escalation_policy={'id': 'escalation_policy'})
+    assert oncall.id == ':schedule:escalation_policy'
+
+    oncall = pygerduty.v2.Oncall(
+            collection=collection,
+            user={'id': 'user'},
+            escalation_policy={'id': 'escalation_policy'})
+    assert oncall.id == 'user::escalation_policy'
+
+    oncall = pygerduty.v2.Oncall(
+            collection=collection,
+            user={'id': 'user'},
+            schedule={'id': 'schedule'})
+    assert oncall.id == 'user:schedule:'


### PR DESCRIPTION
These fields are optional according to schema and have been None in practice, breaking attempts to query oncalls.