### PR TITLE
Consolidate exceptions

### DIFF
--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -8,7 +8,7 @@ import re
 import six
 from six import string_types
 from six.moves import urllib
-from exceptions import Error, IntegrationAPIError, BadRequest
+from exceptions import Error, IntegrationAPIError, BadRequest, NotFound
 
 __author__ = "Mike Cugini <cugini@dropbox.com>"
 from .version import __version__, version_info  # noqa

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -8,7 +8,7 @@ import re
 import six
 from six import string_types
 from six.moves import urllib
-from exceptions import Error, IntegrationAPIError
+from exceptions import Error, IntegrationAPIError, BadRequest
 
 __author__ = "Mike Cugini <cugini@dropbox.com>"
 from .version import __version__, version_info  # noqa

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -8,7 +8,7 @@ import re
 import six
 from six import string_types
 from six.moves import urllib
-
+from exceptions import Error, IntegrationAPIError
 
 __author__ = "Mike Cugini <cugini@dropbox.com>"
 from .version import __version__, version_info  # noqa
@@ -22,39 +22,6 @@ ISO8601_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 # TODO:
 # Support for Log Entries
 # Support for Reports
-
-
-class Error(Exception):
-    pass
-
-
-class IntegrationAPIError(Error):
-    def __init__(self, message, event_type):
-        self.event_type = event_type
-        self.message = message
-
-    def __str__(self):
-        return "Creating {0} event failed: {1}".format(self.event_type,
-                                                       self.message)
-
-
-class BadRequest(Error):
-    def __init__(self, payload, *args, **kwargs):
-        # Error Reponses don't always contain all fields.
-        # Sane defaults must be set.
-        self.code = payload.get("error", {}).get('code', 99999)
-        self.errors = payload.get("error", {}).get('errors', [])
-        self.message = payload.get("error", {}).get('message', str(payload))
-
-        Error.__init__(self, *args, **kwargs)
-
-    def __str__(self):
-        return "{0} ({1}): {2}".format(
-            self.message, self.code, self.errors)
-
-
-class NotFound(Error):
-    pass
 
 
 class Collection(object):

--- a/pygerduty/__init__.py
+++ b/pygerduty/__init__.py
@@ -8,7 +8,7 @@ import re
 import six
 from six import string_types
 from six.moves import urllib
-from exceptions import Error, IntegrationAPIError, BadRequest, NotFound
+from .exceptions import Error, IntegrationAPIError, BadRequest, NotFound
 
 __author__ = "Mike Cugini <cugini@dropbox.com>"
 from .version import __version__, version_info  # noqa

--- a/pygerduty/common.py
+++ b/pygerduty/common.py
@@ -2,7 +2,7 @@
 import datetime
 import functools
 import json
-from .exceptions import BadRequest, NotFound, Error, IntegrationAPIError
+from .exceptions import Error, IntegrationAPIError, BadRequest, NotFound
 from six import string_types
 from six.moves import urllib
 

--- a/pygerduty/common.py
+++ b/pygerduty/common.py
@@ -2,33 +2,11 @@
 import datetime
 import functools
 import json
+from exceptions import BadRequest, NotFound
 from six import string_types
 from six.moves import urllib
 
 ISO8601_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
-
-
-class Error(Exception):
-    pass
-
-
-class BadRequest(Error):
-    def __init__(self, payload, *args, **kwargs):
-        # Error Reponses don't always contain all fields.
-        # Sane defaults must be set.
-        self.code = payload.get("error", {}).get('code', 99999)
-        self.errors = payload.get("error", {}).get('errors', [])
-        self.message = payload.get("error", {}).get('message', str(payload))
-
-        Error.__init__(self, *args, **kwargs)
-
-    def __str__(self):
-        return "{0} ({1}): {2}".format(
-            self.message, self.code, self.errors)
-
-
-class NotFound(Error):
-    pass
 
 
 class Requester(object):

--- a/pygerduty/common.py
+++ b/pygerduty/common.py
@@ -2,7 +2,7 @@
 import datetime
 import functools
 import json
-from .exceptions import BadRequest, NotFound
+from .exceptions import BadRequest, NotFound, Error, IntegrationAPIError
 from six import string_types
 from six.moves import urllib
 

--- a/pygerduty/common.py
+++ b/pygerduty/common.py
@@ -2,7 +2,7 @@
 import datetime
 import functools
 import json
-from exceptions import BadRequest, NotFound
+from .exceptions import BadRequest, NotFound
 from six import string_types
 from six.moves import urllib
 

--- a/pygerduty/events.py
+++ b/pygerduty/events.py
@@ -2,24 +2,14 @@
 # Pagerduty Events API.
 
 from six.moves import urllib
+from exceptions import IntegrationAPIError
 from .common import (
     _json_dumper,
-    Error,
     Requester,
 )
 
 INTEGRATION_API_URL =\
     "https://events.pagerduty.com/generic/2010-04-15/create_event.json"
-
-
-class IntegrationAPIError(Error):
-    def __init__(self, message, event_type):
-        self.event_type = event_type
-        self.message = message
-
-    def __str__(self):
-        return "Creating {0} event failed: {1}".format(self.event_type,
-                                                       self.message)
 
 
 class Events(object):

--- a/pygerduty/events.py
+++ b/pygerduty/events.py
@@ -2,7 +2,7 @@
 # Pagerduty Events API.
 
 from six.moves import urllib
-from .exceptions import IntegrationAPIError
+from .exceptions import IntegrationAPIError, NotFound, Error, BadRequest
 from .common import (
     _json_dumper,
     Requester,

--- a/pygerduty/events.py
+++ b/pygerduty/events.py
@@ -2,7 +2,7 @@
 # Pagerduty Events API.
 
 from six.moves import urllib
-from exceptions import IntegrationAPIError
+from .exceptions import IntegrationAPIError
 from .common import (
     _json_dumper,
     Requester,

--- a/pygerduty/events.py
+++ b/pygerduty/events.py
@@ -2,7 +2,7 @@
 # Pagerduty Events API.
 
 from six.moves import urllib
-from .exceptions import IntegrationAPIError, NotFound, Error, BadRequest
+from .exceptions import Error, IntegrationAPIError, BadRequest, NotFound
 from .common import (
     _json_dumper,
     Requester,

--- a/pygerduty/exceptions.py
+++ b/pygerduty/exceptions.py
@@ -1,0 +1,31 @@
+class Error(Exception):
+    pass
+
+
+class IntegrationAPIError(Error):
+    def __init__(self, message, event_type):
+        self.event_type = event_type
+        self.message = message
+
+    def __str__(self):
+        return "Creating {0} event failed: {1}".format(self.event_type,
+                                                       self.message)
+
+
+class BadRequest(Error):
+    def __init__(self, payload, *args, **kwargs):
+        # Error Responses don't always contain all fields.
+        # Sane defaults must be set.
+        self.code = payload.get("error", {}).get('code', 99999)
+        self.errors = payload.get("error", {}).get('errors', [])
+        self.message = payload.get("error", {}).get('message', str(payload))
+
+        Error.__init__(self, *args)
+
+    def __str__(self):
+        return "{0} ({1}): {2}".format(
+            self.message, self.code, self.errors)
+
+
+class NotFound(Error):
+    pass

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -2,7 +2,7 @@ import copy
 import re
 import six
 from six.moves import urllib
-from .exceptions import Error
+from .exceptions import Error, BadRequest, IntegrationAPIError, NotFound
 from .common import (
     Requester,
     _lower,

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -2,6 +2,7 @@ import copy
 import re
 import six
 from six.moves import urllib
+from exceptions import Error
 from .common import (
     Requester,
     _lower,

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -2,7 +2,7 @@ import copy
 import re
 import six
 from six.moves import urllib
-from .exceptions import Error, BadRequest, IntegrationAPIError, NotFound
+from .exceptions import Error, IntegrationAPIError, BadRequest, NotFound
 from .common import (
     Requester,
     _lower,

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -23,29 +23,6 @@ TRIGGER_LOG_ENTRY_RE = re.compile(
 # Support for Reports
 
 
-class Error(Exception):
-    pass
-
-
-class BadRequest(Error):
-    def __init__(self, payload, *args, **kwargs):
-        # Error Reponses don't always contain all fields.
-        # Sane defaults must be set.
-        self.code = payload.get("error", {}).get('code', 99999)
-        self.errors = payload.get("error", {}).get('errors', [])
-        self.message = payload.get("error", {}).get('message', str(payload))
-
-        Error.__init__(self, *args, **kwargs)
-
-    def __str__(self):
-        return "{0} ({1}): {2}".format(
-            self.message, self.code, self.errors)
-
-
-class NotFound(Error):
-    pass
-
-
 class Collection(object):
     paginated = True
     default_query_params = {}

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -2,7 +2,7 @@ import copy
 import re
 import six
 from six.moves import urllib
-from exceptions import Error
+from .exceptions import Error
 from .common import (
     Requester,
     _lower,

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ commands =
     {envpython} setup.py test
 
 [flake8]
-ignore = E265,E309,E501
+ignore = E265,E309,E501,F401


### PR DESCRIPTION
I was troubleshooting a bug today in our code and noticed that these exceptions are defined in multiple places.  I was attempting to catch pygerduty.v2.BadRequest and was getting pygerduty.common.BadRequest instead.

These can all be defined in one place and imported.  That way, when you throw the exception it is always an instance of the same class.

Thanks!