### PR TITLE
Support Collection.count() and exponential-backoff-and-retry

### DIFF
--- a/pygerduty/common.py
+++ b/pygerduty/common.py
@@ -35,11 +35,6 @@ class Requester(object):
         try:
             response = (self.opener.open(request, timeout=self.timeout).
                         read().decode("utf-8"))
-        except urllib.error.URLError:
-            if retry_count < self.max_retries:
-                return self.execute_request(request, retry_count + 1)
-            else:
-                raise
         except urllib.error.HTTPError as err:
             if err.code / 100 == 2:
                 response = err.read().decode("utf-8")
@@ -55,6 +50,11 @@ class Requester(object):
                     return self.execute_request(request, retry_count + 1)
                 else:
                     raise
+            else:
+                raise
+        except urllib.error.URLError:
+            if retry_count < self.max_retries:
+                return self.execute_request(request, retry_count + 1)
             else:
                 raise
 

--- a/pygerduty/common.py
+++ b/pygerduty/common.py
@@ -29,7 +29,7 @@ class Requester(object):
     def execute_request(self, request, retry_count=0):
         if retry_count > 0:
             exponential_backoff = self.min_backoff * (2 ** retry_count)
-            randomness = randint(0,1000) / 1000.0
+            randomness = randint(0, 1000) / 1000.0
             sleep(exponential_backoff + randomness)
 
         try:

--- a/pygerduty/common.py
+++ b/pygerduty/common.py
@@ -35,7 +35,7 @@ class Requester(object):
         try:
             response = (self.opener.open(request, timeout=self.timeout).
                         read().decode("utf-8"))
-        except urllib.error.URLError as err:
+        except urllib.error.URLError:
             if retry_count < self.max_retries:
                 return self.execute_request(request, retry_count + 1)
             else:

--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -175,7 +175,12 @@ class Collection(object):
                     break
 
     def count(self, **kwargs):
-        path = "{0}/count".format(self.name)
+        path = "{0}".format(self.name)
+        kwargs["total"] = "true"
+        if self.base_container:
+            path = "{0}/{1}/{2}".format(
+                self.base_container.collection.name,
+                self.base_container.id, self.name)
         response = self.pagerduty.request("GET", path, query_params=kwargs)
         return response.get("total", None)
 

--- a/tests/fixtures/incident_log_entries.json
+++ b/tests/fixtures/incident_log_entries.json
@@ -1,0 +1,592 @@
+{
+  "log_entries": [
+    {
+      "service": {
+        "self": "https://api.pagerduty.com/services/P0K4MD5",
+        "summary": "Test Service",
+        "type": "service_reference",
+        "id": "P0K4MD5",
+        "html_url": "https://subdomain.pagerduty.com/services/P0K4MD5"
+      },
+      "contexts": [],
+      "created_at": "2019-01-01T00:57:11Z",
+      "html_url": null,
+      "agent": {
+        "self": "https://api.pagerduty.com/services/P0K4MD5/integrations/PM4L3BM",
+        "summary": "Test-Service-API-v2",
+        "type": "events_api_v2_inbound_integration_reference",
+        "id": "PM4L3BM",
+        "html_url": "https://subdomain.pagerduty.com/services/P0K4MD5/integrations/PM4L3BM"
+      },
+      "teams": [
+        {
+          "self": "https://api.pagerduty.com/teams/PL09PSG",
+          "summary": "Team 123",
+          "type": "team_reference",
+          "id": "PL09PSG",
+          "html_url": "https://subdomain.pagerduty.com/teams/PL09PSG"
+        }
+      ],
+      "self": "https://api.pagerduty.com/log_entries/RP2836ITHU9F3ADA1T9MF3F97O",
+      "incident": {
+        "self": "https://api.pagerduty.com/incidents/PT4KHLK",
+        "summary": "[#1234567] The server is on fire.",
+        "type": "incident_reference",
+        "id": "PT4KHLK",
+        "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK"
+      },
+      "id": "RP2836ITHU9F3ADA1T9MF3F97O",
+      "summary": "Resolved through the API",
+      "type": "resolve_log_entry",
+      "event_details": {},
+      "channel": {
+        "type": "integration"
+      }
+    },
+    {
+      "service": {
+        "self": "https://api.pagerduty.com/services/P0K4MD5",
+        "summary": "Test Service",
+        "type": "service_reference",
+        "id": "P0K4MD5",
+        "html_url": "https://subdomain.pagerduty.com/services/P0K4MD5"
+      },
+      "contexts": [],
+      "created_at": "2019-01-01T00:30:01Z",
+      "html_url": null,
+      "teams": [
+        {
+          "self": "https://api.pagerduty.com/teams/PL09PSG",
+          "summary": "Team 123",
+          "type": "team_reference",
+          "id": "PL09PSG",
+          "html_url": "https://subdomain.pagerduty.com/teams/PL09PSG"
+        }
+      ],
+      "self": "https://api.pagerduty.com/log_entries/R2PDIDKABLHDOXPXVG6YQPDJUD",
+      "incident": {
+        "self": "https://api.pagerduty.com/incidents/PT4KHLK",
+        "summary": "[#1234567] The server is on fire.",
+        "type": "incident_reference",
+        "id": "PT4KHLK",
+        "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK"
+      },
+      "user": {
+        "self": "https://api.pagerduty.com/users/PT3D7UU",
+        "summary": "FakeUser",
+        "type": "user_reference",
+        "id": "PT3D7UU",
+        "html_url": "https://subdomain.pagerduty.com/users/PT3D7UU"
+      },
+      "summary": "Notified FakeUser by email",
+      "type": "notify_log_entry",
+      "id": "R2PDIDKABLHDOXPXVG6YQPDJUD",
+      "channel": {
+        "notification": {
+          "status": "bad_address",
+          "conferenceAddress": null,
+          "type": "email",
+          "address": "FakeUser@subdomain.com"
+        },
+        "type": "auto"
+      }
+    },
+    {
+      "service": {
+        "self": "https://api.pagerduty.com/services/P0K4MD5",
+        "summary": "Test Service",
+        "type": "service_reference",
+        "id": "P0K4MD5",
+        "html_url": "https://subdomain.pagerduty.com/services/P0K4MD5"
+      },
+      "contexts": [],
+      "created_at": "2019-01-01T00:17:26Z",
+      "html_url": null,
+      "agent": {
+        "self": "https://api.pagerduty.com/users/P2BXFK0",
+        "summary": "FakeUser2",
+        "type": "user_reference",
+        "id": "P2BXFK0",
+        "html_url": "https://subdomain.pagerduty.com/users/P2BXFK0"
+      },
+      "teams": [
+        {
+          "self": "https://api.pagerduty.com/teams/PL09PSG",
+          "summary": "Team 123",
+          "type": "team_reference",
+          "id": "PL09PSG",
+          "html_url": "https://subdomain.pagerduty.com/teams/PL09PSG"
+        }
+      ],
+      "self": "https://api.pagerduty.com/log_entries/RQ84W5G7Y0VQ2JFN5U85PFUGKK",
+      "incident": {
+        "self": "https://api.pagerduty.com/incidents/PT4KHLK",
+        "summary": "[#1234567] The server is on fire.",
+        "type": "incident_reference",
+        "id": "PT4KHLK",
+        "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK"
+      },
+      "summary": "Snoozed by FakeUser2 for 8 hrs 0 min",
+      "type": "snooze_log_entry",
+      "id": "RQ84W5G7Y0VQ2JFN5U85PFUGKK",
+      "channel": {
+        "duration": 28800,
+        "type": "website"
+      },
+      "changed_actions": [
+        {
+          "type": "unacknowledge",
+          "at": "2019-01-01T08:17:26Z"
+        }
+      ]
+    },
+    {
+      "service": {
+        "self": "https://api.pagerduty.com/services/P0K4MD5",
+        "summary": "Test Service",
+        "type": "service_reference",
+        "id": "P0K4MD5",
+        "html_url": "https://subdomain.pagerduty.com/services/P0K4MD5"
+      },
+      "contexts": [],
+      "created_at": "2019-01-01T00:10:49Z",
+      "teams": [
+        {
+          "self": "https://api.pagerduty.com/teams/PL09PSG",
+          "summary": "Team 123",
+          "type": "team_reference",
+          "id": "PL09PSG",
+          "html_url": "https://subdomain.pagerduty.com/teams/PL09PSG"
+        }
+      ],
+      "html_url": null,
+      "agent": {
+        "self": "https://api.pagerduty.com/users/P2BXFK0",
+        "summary": "FakeUser2",
+        "type": "user_reference",
+        "id": "P2BXFK0",
+        "html_url": "https://subdomain.pagerduty.com/users/P2BXFK0"
+      },
+      "acknowledgement_timeout": 7200,
+      "self": "https://api.pagerduty.com/log_entries/R01BG1J3L9NLRCC69YS7BNFNBB",
+      "incident": {
+        "self": "https://api.pagerduty.com/incidents/PT4KHLK",
+        "summary": "[#1234567] The server is on fire.",
+        "type": "incident_reference",
+        "id": "PT4KHLK",
+        "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK"
+      },
+      "id": "R01BG1J3L9NLRCC69YS7BNFNBB",
+      "summary": "Acknowledged by FakeUser2",
+      "type": "acknowledge_log_entry",
+      "event_details": {},
+      "channel": {
+        "type": "website"
+      }
+    },
+    {
+      "service": {
+        "self": "https://api.pagerduty.com/services/P0K4MD5",
+        "summary": "Test Service",
+        "type": "service_reference",
+        "id": "P0K4MD5",
+        "html_url": "https://subdomain.pagerduty.com/services/P0K4MD5"
+      },
+      "contexts": [],
+      "created_at": "2019-01-01T00:08:43Z",
+      "html_url": null,
+      "teams": [
+        {
+          "self": "https://api.pagerduty.com/teams/PL09PSG",
+          "summary": "Team 123",
+          "type": "team_reference",
+          "id": "PL09PSG",
+          "html_url": "https://subdomain.pagerduty.com/teams/PL09PSG"
+        }
+      ],
+      "self": "https://api.pagerduty.com/log_entries/R09XFP122Z3S4J8B9S8DWELVYZ",
+      "incident": {
+        "self": "https://api.pagerduty.com/incidents/PT4KHLK",
+        "summary": "[#1234567] The server is on fire.",
+        "type": "incident_reference",
+        "id": "PT4KHLK",
+        "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK"
+      },
+      "user": {
+        "self": "https://api.pagerduty.com/users/P2BXFK0",
+        "summary": "FakeUser2",
+        "type": "user_reference",
+        "id": "P2BXFK0",
+        "html_url": "https://subdomain.pagerduty.com/users/P2BXFK0"
+      },
+      "summary": "Notified FakeUser2 by push notification",
+      "type": "notify_log_entry",
+      "id": "R09XFP122Z3S4J8B9S8DWELVYZ",
+      "channel": {
+        "notification": {
+          "status": "success",
+          "conferenceAddress": null,
+          "type": "android_push_notification",
+          "address": "SM-N9005"
+        },
+        "type": "auto"
+      }
+    },
+    {
+      "service": {
+        "self": "https://api.pagerduty.com/services/P0K4MD5",
+        "summary": "Test Service",
+        "type": "service_reference",
+        "id": "P0K4MD5",
+        "html_url": "https://subdomain.pagerduty.com/services/P0K4MD5"
+      },
+      "contexts": [],
+      "created_at": "2019-01-01T00:08:34Z",
+      "html_url": null,
+      "teams": [
+        {
+          "self": "https://api.pagerduty.com/teams/PL09PSG",
+          "summary": "Team 123",
+          "type": "team_reference",
+          "id": "PL09PSG",
+          "html_url": "https://subdomain.pagerduty.com/teams/PL09PSG"
+        }
+      ],
+      "self": "https://api.pagerduty.com/log_entries/RNJ5P6LTMD7GBKQPTWSFUT7094",
+      "incident": {
+        "self": "https://api.pagerduty.com/incidents/PT4KHLK",
+        "summary": "[#1234567] The server is on fire.",
+        "type": "incident_reference",
+        "id": "PT4KHLK",
+        "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK"
+      },
+      "user": {
+        "self": "https://api.pagerduty.com/users/P2BXFK0",
+        "summary": "FakeUser2",
+        "type": "user_reference",
+        "id": "P2BXFK0",
+        "html_url": "https://subdomain.pagerduty.com/users/P2BXFK0"
+      },
+      "summary": "Notified FakeUser2 by push notification",
+      "type": "notify_log_entry",
+      "id": "RNJ5P6LTMD7GBKQPTWSFUT7094",
+      "channel": {
+        "notification": {
+          "status": "success",
+          "conferenceAddress": null,
+          "type": "android_push_notification",
+          "address": "MI 5"
+        },
+        "type": "auto"
+      }
+    },
+    {
+      "service": {
+        "self": "https://api.pagerduty.com/services/P0K4MD5",
+        "summary": "Test Service",
+        "type": "service_reference",
+        "id": "P0K4MD5",
+        "html_url": "https://subdomain.pagerduty.com/services/P0K4MD5"
+      },
+      "contexts": [],
+      "created_at": "2019-01-01T00:08:24Z",
+      "html_url": null,
+      "teams": [
+        {
+          "self": "https://api.pagerduty.com/teams/PL09PSG",
+          "summary": "Team 123",
+          "type": "team_reference",
+          "id": "PL09PSG",
+          "html_url": "https://subdomain.pagerduty.com/teams/PL09PSG"
+        }
+      ],
+      "self": "https://api.pagerduty.com/log_entries/RP0FXADPZIDGOCSKC76A8F2KXS",
+      "incident": {
+        "self": "https://api.pagerduty.com/incidents/PT4KHLK",
+        "summary": "[#1234567] The server is on fire.",
+        "type": "incident_reference",
+        "id": "PT4KHLK",
+        "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK"
+      },
+      "user": {
+        "self": "https://api.pagerduty.com/users/P2BXFK0",
+        "summary": "FakeUser2",
+        "type": "user_reference",
+        "id": "P2BXFK0",
+        "html_url": "https://subdomain.pagerduty.com/users/P2BXFK0"
+      },
+      "summary": "Notified FakeUser2 by push notification",
+      "type": "notify_log_entry",
+      "id": "RP0FXADPZIDGOCSKC76A8F2KXS",
+      "channel": {
+        "notification": {
+          "status": "success",
+          "conferenceAddress": null,
+          "type": "android_push_notification",
+          "address": "SM-A520F"
+        },
+        "type": "auto"
+      }
+    },
+    {
+      "service": {
+        "self": "https://api.pagerduty.com/services/P0K4MD5",
+        "summary": "Test Service",
+        "type": "service_reference",
+        "id": "P0K4MD5",
+        "html_url": "https://subdomain.pagerduty.com/services/P0K4MD5"
+      },
+      "contexts": [],
+      "created_at": "2019-01-01T00:08:12Z",
+      "html_url": null,
+      "agent": {
+        "self": "https://api.pagerduty.com/services/P0K4MD5",
+        "summary": "Test Service",
+        "type": "service_reference",
+        "id": "P0K4MD5",
+        "html_url": "https://subdomain.pagerduty.com/services/P0K4MD5"
+      },
+      "teams": [
+        {
+          "self": "https://api.pagerduty.com/teams/PL09PSG",
+          "summary": "Team 123",
+          "type": "team_reference",
+          "id": "PL09PSG",
+          "html_url": "https://subdomain.pagerduty.com/teams/PL09PSG"
+        }
+      ],
+      "self": "https://api.pagerduty.com/log_entries/R23A105I7I0HS4BUWWTEI79OV4",
+      "assignees": [
+        {
+          "self": "https://api.pagerduty.com/users/P2BXFK0",
+          "summary": "FakeUser2",
+          "type": "user_reference",
+          "id": "P2BXFK0",
+          "html_url": "https://subdomain.pagerduty.com/users/P2BXFK0"
+        }
+      ],
+      "incident": {
+        "self": "https://api.pagerduty.com/incidents/PT4KHLK",
+        "summary": "[#1234567] The server is on fire.",
+        "type": "incident_reference",
+        "id": "PT4KHLK",
+        "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK"
+      },
+      "summary": "Escalated to FakeUser2 through the API",
+      "type": "escalate_log_entry",
+      "id": "R23A105I7I0HS4BUWWTEI79OV4",
+      "channel": {
+        "type": "timeout"
+      }
+    },
+    {
+      "service": {
+        "self": "https://api.pagerduty.com/services/P0K4MD5",
+        "summary": "Test Service",
+        "type": "service_reference",
+        "id": "P0K4MD5",
+        "html_url": "https://subdomain.pagerduty.com/services/P0K4MD5"
+      },
+      "contexts": [],
+      "created_at": "2019-01-01T00:03:12Z",
+      "html_url": null,
+      "agent": {
+        "self": "https://api.pagerduty.com/services/P0K4MD5/integrations/PM4L3BM",
+        "summary": "Test-Service-API-v2",
+        "type": "events_api_v2_inbound_integration_reference",
+        "id": "PM4L3BM",
+        "html_url": "https://subdomain.pagerduty.com/services/P0K4MD5/integrations/PM4L3BM"
+      },
+      "teams": [
+        {
+          "self": "https://api.pagerduty.com/teams/PL09PSG",
+          "summary": "Team 123",
+          "type": "team_reference",
+          "id": "PL09PSG",
+          "html_url": "https://subdomain.pagerduty.com/teams/PL09PSG"
+        }
+      ],
+      "self": "https://api.pagerduty.com/log_entries/R1LRHYM5AS4Z5CM1SPMCX3R32U",
+      "incident": {
+        "self": "https://api.pagerduty.com/incidents/PT4KHLK",
+        "summary": "[#1234567] The server is on fire.",
+        "type": "incident_reference",
+        "id": "PT4KHLK",
+        "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK"
+      },
+      "summary": "Event rule set urgency to high through the API",
+      "type": "event_rule_action_log_entry",
+      "id": "R1LRHYM5AS4Z5CM1SPMCX3R32U",
+      "channel": {
+        "alert_based_severity": "critical",
+        "type": "",
+        "urgency": "high"
+      }
+    },
+    {
+      "service": {
+        "self": "https://api.pagerduty.com/services/P0K4MD5",
+        "summary": "Test Service",
+        "type": "service_reference",
+        "id": "P0K4MD5",
+        "html_url": "https://subdomain.pagerduty.com/services/P0K4MD5"
+      },
+      "contexts": [],
+      "created_at": "2019-01-01T00:03:12Z",
+      "linked_incident": {
+        "self": "https://api.pagerduty.com/alerts/P61BLED",
+        "summary": "The server is on fire.",
+        "type": "alert_reference",
+        "id": "P61BLED",
+        "html_url": "https://subdomain.pagerduty.com/alerts/P61BLED"
+      },
+      "html_url": null,
+      "agent": {
+        "self": "https://api.pagerduty.com/services/P0K4MD5",
+        "summary": "Test Service",
+        "type": "service_reference",
+        "id": "P0K4MD5",
+        "html_url": "https://subdomain.pagerduty.com/services/P0K4MD5"
+      },
+      "teams": [
+        {
+          "self": "https://api.pagerduty.com/teams/PL09PSG",
+          "summary": "Team 123",
+          "type": "team_reference",
+          "id": "PL09PSG",
+          "html_url": "https://subdomain.pagerduty.com/teams/PL09PSG"
+        }
+      ],
+      "self": "https://api.pagerduty.com/log_entries/R9KU0JVDG26SY99UHIRV6WD1JU",
+      "incident": {
+        "self": "https://api.pagerduty.com/incidents/PT4KHLK",
+        "summary": "[#1234567] The server is on fire.",
+        "type": "incident_reference",
+        "id": "PT4KHLK",
+        "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK"
+      },
+      "summary": "Alert \"The server is on fire.\" added through the API",
+      "type": "link_log_entry",
+      "id": "R9KU0JVDG26SY99UHIRV6WD1JU",
+      "channel": {
+        "type": "website"
+      }
+    },
+    {
+      "service": {
+        "self": "https://api.pagerduty.com/services/P0K4MD5",
+        "summary": "Test Service",
+        "type": "service_reference",
+        "id": "P0K4MD5",
+        "html_url": "https://subdomain.pagerduty.com/services/P0K4MD5"
+      },
+      "contexts": [],
+      "created_at": "2019-01-01T00:03:12Z",
+      "html_url": null,
+      "agent": {
+        "self": "https://api.pagerduty.com/services/P0K4MD5",
+        "summary": "Test Service",
+        "type": "service_reference",
+        "id": "P0K4MD5",
+        "html_url": "https://subdomain.pagerduty.com/services/P0K4MD5"
+      },
+      "teams": [
+        {
+          "self": "https://api.pagerduty.com/teams/PL09PSG",
+          "summary": "Team 123",
+          "type": "team_reference",
+          "id": "PL09PSG",
+          "html_url": "https://subdomain.pagerduty.com/teams/PL09PSG"
+        }
+      ],
+      "self": "https://api.pagerduty.com/log_entries/R4S2OL7UGPYDHV0CQ3C7IMP3WX",
+      "assignees": [
+        {
+          "self": "https://api.pagerduty.com/users/PT3D7UU",
+          "summary": "FakeUser1",
+          "type": "user_reference",
+          "id": "PT3D7UU",
+          "html_url": "https://subdomain.pagerduty.com/users/PT3D7UU"
+        }
+      ],
+      "incident": {
+        "self": "https://api.pagerduty.com/incidents/PT4KHLK",
+        "summary": "[#1234567] The server is on fire.",
+        "type": "incident_reference",
+        "id": "PT4KHLK",
+        "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK"
+      },
+      "summary": "Assigned to FakeUser1",
+      "type": "assign_log_entry",
+      "id": "R4S2OL7UGPYDHV0CQ3C7IMP3WX",
+      "channel": {
+        "type": "auto"
+      }
+    },
+    {
+      "service": {
+        "self": "https://api.pagerduty.com/services/P0K4MD5",
+        "summary": "Test Service",
+        "type": "service_reference",
+        "id": "P0K4MD5",
+        "html_url": "https://subdomain.pagerduty.com/services/P0K4MD5"
+      },
+      "contexts": [],
+      "created_at": "2019-01-01T00:03:12Z",
+      "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK/log_entries/RNSAN8BDFJ9LJXR92T19ERR70D",
+      "agent": {
+        "self": "https://api.pagerduty.com/services/P0K4MD5/integrations/PM4L3BM",
+        "summary": "Test-Service-API-v2",
+        "type": "events_api_v2_inbound_integration_reference",
+        "id": "PM4L3BM",
+        "html_url": "https://subdomain.pagerduty.com/services/P0K4MD5/integrations/PM4L3BM"
+      },
+      "teams": [
+        {
+          "self": "https://api.pagerduty.com/teams/PL09PSG",
+          "summary": "Team 123",
+          "type": "team_reference",
+          "id": "PL09PSG",
+          "html_url": "https://subdomain.pagerduty.com/teams/PL09PSG"
+        }
+      ],
+      "self": "https://api.pagerduty.com/log_entries/RNSAN8BDFJ9LJXR92T19ERR70D",
+      "incident": {
+        "self": "https://api.pagerduty.com/incidents/PT4KHLK",
+        "summary": "[#1234567] The server is on fire.",
+        "type": "incident_reference",
+        "id": "PT4KHLK",
+        "html_url": "https://subdomain.pagerduty.com/incidents/PT4KHLK"
+      },
+      "id": "RNSAN8BDFJ9LJXR92T19ERR70D",
+      "summary": "Triggered through the API",
+      "type": "trigger_log_entry",
+      "event_details": {
+        "description": "The server is on fire."
+      },
+      "channel": {
+        "cef_details": {
+          "severity": "critical",
+          "contexts": [],
+          "mutations": [],
+          "dedup_key": "The server is on fire.",
+          "version": "1.0",
+          "source_origin": "localhost",
+          "details": {},
+          "message": "The server is on fire.",
+          "description": "The server is on fire."
+        },
+        "description": "The server is on fire.",
+        "summary": "The server is on fire.",
+        "incident_key": "The server is on fire.",
+        "details": {},
+        "service_key": "b48db8033932495b827ebb1b3f825920",
+        "type": "api"
+      }
+    }
+  ],
+  "limit": 25,
+  "offset": 0,
+  "total": 12,
+  "more": false
+}

--- a/tests/incident_test.py
+++ b/tests/incident_test.py
@@ -142,7 +142,7 @@ def test_log_entries_count():
     assert total == 12
     
 @httpretty.activate
-def test_log_entries_list():
+def test_log_entries_list_offset():
     body1 = open('tests/fixtures/get_incident_v2.json').read()
     httpretty.register_uri(
         httpretty.GET, "https://api.pagerduty.com/incidents/PT4KHLK",
@@ -162,6 +162,18 @@ def test_log_entries_list():
     assert len(log_entries) == 12
     assert log_entries[0].created_at == '2019-01-01T00:57:11Z'
     assert log_entries[0].self_ == 'https://api.pagerduty.com/log_entries/RP2836ITHU9F3ADA1T9MF3F97O'
+
+@httpretty.activate
+def test_log_entries_list():
+    body1 = open('tests/fixtures/get_incident_v2.json').read()
+    httpretty.register_uri(
+        httpretty.GET, "https://api.pagerduty.com/incidents/PT4KHLK",
+        body=body1, status=200)
+
+    p = pygerduty.v2.PagerDuty("password")
+    incident = p.incidents.show("PT4KHLK")
+    assert str(incident.id) == "PT4KHLK"
+    assert incident.created_at == '2015-10-06T21:30:42Z'
 
     body2 = open('tests/fixtures/incident_log_entries.json').read()
     httpretty.register_uri(

--- a/tests/incident_test.py
+++ b/tests/incident_test.py
@@ -120,3 +120,67 @@ def test_reassign_v2():
 
     assert len(incident1.assignments) == 0
     assert len(incident2.assignments) == 2
+
+@httpretty.activate
+def test_log_entries_count():
+    body1 = open('tests/fixtures/get_incident_v2.json').read()
+    httpretty.register_uri(
+        httpretty.GET, "https://api.pagerduty.com/incidents/PT4KHLK",
+        body=body1, status=200)
+
+    p = pygerduty.v2.PagerDuty("password")
+    incident = p.incidents.show("PT4KHLK")
+    assert str(incident.id) == "PT4KHLK"
+    assert incident.created_at == '2015-10-06T21:30:42Z'
+
+    body2 = open('tests/fixtures/incident_log_entries.json').read()
+    httpretty.register_uri(
+        httpretty.GET, "https://api.pagerduty.com/incidents/PT4KHLK/log_entries",
+        body=body2, status=200)
+
+    total = incident.log_entries.count()
+    assert total == 12
+    
+@httpretty.activate
+def test_log_entries_list():
+    body1 = open('tests/fixtures/get_incident_v2.json').read()
+    httpretty.register_uri(
+        httpretty.GET, "https://api.pagerduty.com/incidents/PT4KHLK",
+        body=body1, status=200)
+
+    p = pygerduty.v2.PagerDuty("password")
+    incident = p.incidents.show("PT4KHLK")
+    assert str(incident.id) == "PT4KHLK"
+    assert incident.created_at == '2015-10-06T21:30:42Z'
+
+    body2 = open('tests/fixtures/incident_log_entries.json').read()
+    httpretty.register_uri(
+        httpretty.GET, "https://api.pagerduty.com/incidents/PT4KHLK/log_entries",
+        body=body2, status=200)
+
+    log_entries = [i for i in incident.log_entries.list(offset=0,limit=25)]
+    assert len(log_entries) == 12
+    assert log_entries[0].created_at == '2019-01-01T00:57:11Z'
+    assert log_entries[0].self_ == 'https://api.pagerduty.com/log_entries/RP2836ITHU9F3ADA1T9MF3F97O'
+
+    body2 = open('tests/fixtures/incident_log_entries.json').read()
+    httpretty.register_uri(
+        httpretty.GET, "https://api.pagerduty.com/incidents/PT4KHLK/log_entries",
+        responses=[
+            httpretty.Response(body=body2, status=200),
+            httpretty.Response(body=textwrap.dedent("""\
+                {
+                    "limit": 25,
+                    "more": false,
+                    "offset": 13,
+                    "log_entries": [],
+                    "total": null
+                }
+            """), status=200)
+        ]
+    )
+
+    log_entries = [i for i in incident.log_entries.list()]
+    assert len(log_entries) == 12
+    assert log_entries[0].created_at == '2019-01-01T00:57:11Z'
+    assert log_entries[0].self_ == 'https://api.pagerduty.com/log_entries/RP2836ITHU9F3ADA1T9MF3F97O'


### PR DESCRIPTION
1. External pagination required the **Collection**._count_() method to be updated to support when the base_container is not None (ex: when it is an Incident). This looks like it was probably an oversight originally, as most other **Collection** methods already take this into consideration.
2. Pagination in the v2 REST API does not use the "count" endpoint anymore. Though empirical evidence suggests they have not removed support for it on the main incidents list, there are multiple documentation/community references that suggest it is no longer supported.
3. Threading-off pages as parallel requests (note to use one **PagerDuty** instance per thread) rapidly causes requests to run into **HTTP**(429) and **URLError**(), eliciting the need for an exponential-backoff-and-retry loop.