### PR TITLE
Add enable extension API

### DIFF
--- a/pygerduty/v2.py
+++ b/pygerduty/v2.py
@@ -316,7 +316,10 @@ class EmailFilters(Collection):
 
 
 class Extensions(Collection):
-    pass
+    def enable(self, entity_id):
+        path = "{0}/{1}/enable".format(self.name, entity_id)
+        response = self.pagerduty.request("POST", path)
+        return self.container(self, **response.get(self.sname, {}))
 
 
 class Addons(Collection):

--- a/tests/extensions_test.py
+++ b/tests/extensions_test.py
@@ -58,3 +58,19 @@ def test_list_extensions_v2():
     assert len(extensions[1].extension_objects) == 1
     ext_obj1 = extensions[1].extension_objects[0]
     assert ext_obj1.id == 'PIJ90N8'
+
+
+@httpretty.activate
+def test_enable_extension_v2():
+    body = open('tests/fixtures/get_extension_v2.json').read()
+    httpretty.register_uri(
+        httpretty.POST, "https://api.pagerduty.com/extensions/PPGPXHO/enable",
+        body=body, status=200)
+    p = pygerduty.v2.PagerDuty("password")
+    extension = p.extensions.enable("PPGPXHO")
+
+    assert extension.self_ == 'https://api.pagerduty.com/extensions/PPGPXHO'
+    assert extension.endpoint_url == 'https://example.com/recieve_a_pagerduty_webhook'
+    assert len(extension.extension_objects) == 1
+    ext_obj = extension.extension_objects[0]
+    assert ext_obj.id == 'PIJ90N7'


### PR DESCRIPTION
Hi, I'd like to add support of a relatively new API to enable an extension which is temporarily disabled by PagerDuty.

API reference: https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1extensions~1%7Bid%7D~1enable/post